### PR TITLE
Add language tags and optional infra dirs

### DIFF
--- a/.config/cursor/cursor-rules.yaml
+++ b/.config/cursor/cursor-rules.yaml
@@ -5,3 +5,47 @@ preferences:
 
 include:
   - ~/.config/cursor/generated/tools.yaml
+
+# Preferred languages and frameworks
+languages:
+  preferred:
+    - rust
+    - python
+    - typescript
+  optional:
+    - bash
+  tags:
+    rust:
+      - backend
+      - systems
+    python:
+      - backend
+      - scripting
+    typescript:
+      - frontend
+
+frontend_frameworks:
+  - next.js (typescript)
+  - react native
+
+backend_frameworks:
+  - flask (python)
+  - actix-web (rust)
+
+project_structure:
+  source_dir: src
+  test_dir: tests
+  infra_dirs:
+    docker: docker/
+    optional:
+      k8s: k8s/
+      terraform: infra/terraform/
+  doc_dirs:
+    design_docs: architecture/
+    markdown: project/
+  prefers_monorepo: false
+  prefers_submodules: true
+
+scaffolding:
+  tool: kickstart
+  config_path: ~/.config/kickstart/config.yaml


### PR DESCRIPTION
## Summary
- update `.config/cursor/cursor-rules.yaml` with language tags
- move bash to optional language list
- mark k8s and terraform infra directories as optional

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6845bdc6b9988331b9eaf4ba9d678371