### PR TITLE
Round-4 review follow-ups

### DIFF
--- a/common/git/hooks/pre-commit
+++ b/common/git/hooks/pre-commit
@@ -18,7 +18,7 @@ cd "$repo_root"
 #   git config jm.hooks.runRepoHooks false   (or --global to flip the default)
 repo_hooks_trusted() {
     # --type=bool normalizes 0/no/off/false; unset or garbage stays trusted
-    [[ "$(git config --type=bool --get jm.hooks.runRepoHooks 2>/dev/null || echo true)" != "false" ]]
+    [[ "$(git config --bool --get jm.hooks.runRepoHooks 2>/dev/null || echo true)" != "false" ]]
 }
 
 run_repo_hook() {

--- a/common/git/hooks/pre-push
+++ b/common/git/hooks/pre-push
@@ -17,7 +17,7 @@ cd "$repo_root"
 #   git config jm.hooks.runRepoHooks false
 repo_hooks_trusted() {
     # --type=bool normalizes 0/no/off/false; unset or garbage stays trusted
-    [[ "$(git config --type=bool --get jm.hooks.runRepoHooks 2>/dev/null || echo true)" != "false" ]]
+    [[ "$(git config --bool --get jm.hooks.runRepoHooks 2>/dev/null || echo true)" != "false" ]]
 }
 
 run_repo_hook() {

--- a/install.sh
+++ b/install.sh
@@ -292,14 +292,16 @@ materialize_target_dir() {
         chain+=("$ancestor")
         ancestor="$(dirname "$ancestor")"
     done
-    # Check from the top down so the outermost symlink is replaced first
-    local i seg resolved
+    # Check from the top down so the outermost symlink is replaced first.
+    # Compare physical paths: DOTFILES_DIR may itself contain symlinks.
+    local i seg resolved repo_real
+    repo_real="$(cd "$DOTFILES_DIR" 2>/dev/null && pwd -P || printf '%s' "$DOTFILES_DIR")"
     for (( i=${#chain[@]}-1; i>=0; i-- )); do
         seg="${chain[$i]}"
         if [[ -L "$seg" ]]; then
             resolved="$(cd "$seg" 2>/dev/null && pwd -P || true)"
             case "$resolved" in
-                "$DOTFILES_DIR"|"$DOTFILES_DIR"/*)
+                "$repo_real"|"$repo_real"/*)
                     log_warning "Replacing legacy symlink into the repo: $seg -> $resolved"
                     rm -f "$seg"
                     mkdir -p "$seg"

--- a/linux/arch/.config/waybar/modules/spotify.sh
+++ b/linux/arch/.config/waybar/modules/spotify.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 class=$(playerctl metadata --player=spotify --format '{{lc(status)}}' 2>/dev/null)
-icon=""
+icon=""
 
 if [[ $class == "playing" ]]; then
   info=$(playerctl metadata --player=spotify --format '{{artist}} - {{title}}')

--- a/scripts/minimal-bashrc.sh
+++ b/scripts/minimal-bashrc.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
 # Ultra-minimal bashrc installer - no git required
-# Usage: curl -sSL https://raw.githubusercontent.com/woud420/dotfiles/master/scripts/minimal-bashrc.sh | bash
+# Usage: curl -fsSL https://raw.githubusercontent.com/woud420/dotfiles/master/scripts/minimal-bashrc.sh | bash
 
 # Just download the essential files directly
 mkdir -p ~/.config/shell-functions
 mkdir -p ~/.config/git
 
 # Download server bashrc
-curl -sSL https://raw.githubusercontent.com/woud420/dotfiles/master/common/shell/.bashrc.server -o ~/.bashrc
+curl -fsSL https://raw.githubusercontent.com/woud420/dotfiles/master/common/shell/.bashrc.server -o ~/.bashrc
 
 # Download GNU aliases
-curl -sSL https://raw.githubusercontent.com/woud420/dotfiles/master/common/shell/.gnu_aliases -o ~/.gnu_aliases
+curl -fsSL https://raw.githubusercontent.com/woud420/dotfiles/master/common/shell/.gnu_aliases -o ~/.gnu_aliases
 
 # Download git config
-curl -sSL https://raw.githubusercontent.com/woud420/dotfiles/master/common/git/.gitconfig -o ~/.gitconfig
+curl -fsSL https://raw.githubusercontent.com/woud420/dotfiles/master/common/git/.gitconfig -o ~/.gitconfig
 
 # Download git commit template
-curl -sSL https://raw.githubusercontent.com/woud420/dotfiles/master/common/git/commit-template.md -o ~/.config/git/commit-template.md
+curl -fsSL https://raw.githubusercontent.com/woud420/dotfiles/master/common/git/commit-template.md -o ~/.config/git/commit-template.md
 
 # Download git hooks (the gitconfig sets core.hooksPath, so they must exist
 # or git stops running ANY hooks, including repo-local ones like husky)
 mkdir -p ~/.config/git/hooks
-curl -sSL https://raw.githubusercontent.com/woud420/dotfiles/master/common/git/hooks/pre-commit -o ~/.config/git/hooks/pre-commit
-curl -sSL https://raw.githubusercontent.com/woud420/dotfiles/master/common/git/hooks/pre-push -o ~/.config/git/hooks/pre-push
+curl -fsSL https://raw.githubusercontent.com/woud420/dotfiles/master/common/git/hooks/pre-commit -o ~/.config/git/hooks/pre-commit
+curl -fsSL https://raw.githubusercontent.com/woud420/dotfiles/master/common/git/hooks/pre-push -o ~/.config/git/hooks/pre-push
 chmod +x ~/.config/git/hooks/pre-commit ~/.config/git/hooks/pre-push
 
 echo "✅ Minimal configs installed! Run: source ~/.bashrc"


### PR DESCRIPTION
Small follow-up to #15: the four survivors from the fourth (regression-focused) adversarial pass, which was cut short by a session limit — 1 confirmed finding plus 3 plausible-but-unverified claims that were cheap to fix regardless. Each fix verified by execution (see commit message).

- Restore the nerd-font Spotify glyph dropped in the round-3 `spotify.sh` rewrite
- `curl -f` in `minimal-bashrc.sh` so HTTP error bodies never become configs or executable hooks
- `jm.hooks.runRepoHooks` now honors all git boolean spellings on any git version (`--bool` vs `--type=bool`)
- `install.sh` repo-symlink protection now engages even when the checkout path itself contains symlinks

Also in this cleanup: PR #14 closed as superseded (its template is byte-identical to master's; its branch was made of the same commits squashed in #15) and its branch deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)