### PR TITLE
Reconcile home-box install, backup, and Firefox state

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+env:
+  # Public CI intentionally never requests credentials for the private submodule.
+  DOTFILES_SKIP_PRIVATE_SKILLS: "1"
+
 jobs:
   # Fast syntax/parse checks that don't need install.sh
   lint:

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -76,6 +76,20 @@ jobs:
         run: |
           useradd -m -s /bin/zsh testuser
           echo "testuser ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+          install -d -o testuser -g testuser \
+            /home/testuser/.mozilla/firefox/test.default/chrome
+          printf '%s\n' \
+            '[InstallTest]' \
+            'Default=test.default' \
+            'Locked=1' \
+            '' \
+            '[Profile0]' \
+            'Name=default' \
+            'IsRelative=1' \
+            'Path=test.default' \
+            'Default=1' \
+            > /home/testuser/.mozilla/firefox/profiles.ini
+          chown testuser:testuser /home/testuser/.mozilla/firefox/profiles.ini
 
       - name: Run install.sh
         shell: bash
@@ -106,6 +120,11 @@ jobs:
               test -f ~/$f && echo "PASS: $f" || { echo "FAIL: $f"; exit 1; }
             done
 
+            echo "=== Firefox profile theme ==="
+            for f in .mozilla/firefox/test.default/user.js .mozilla/firefox/test.default/chrome/userChrome.css .mozilla/firefox/test.default/chrome/userContent.css; do
+              test -f ~/$f && ! test -L ~/$f && echo "PASS: $f (copied)" || { echo "FAIL: $f"; exit 1; }
+            done
+
             echo "=== AI context ==="
             test -f ~/AGENTS.md && echo "PASS: AGENTS.md"
             test -f ~/MACHINE.md && echo "PASS: MACHINE.md"
@@ -113,6 +132,10 @@ jobs:
             echo "=== Audit log ==="
             ls ~/.dotfiles-backup-*/install-audit.tsv > /dev/null && echo "PASS: install audit written"
           '
+
+      - name: Verify live files match the repository
+        run: |
+          su testuser -c "cd /home/testuser/dotfiles && DOTFILES_FULL_INSTALL=1 ./install.sh --check"
 
       - name: Validate Kitty config (headless parse)
         run: |

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -89,7 +89,7 @@ jobs:
             'Path=test.default' \
             'Default=1' \
             > /home/testuser/.mozilla/firefox/profiles.ini
-          chown testuser:testuser /home/testuser/.mozilla/firefox/profiles.ini
+          chown -R testuser:testuser /home/testuser/.mozilla
 
       - name: Run install.sh
         shell: bash

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -346,6 +346,18 @@ jobs:
           git config --file ~/.gitconfig --list > /dev/null 2>&1 && echo "PASS: .gitconfig" || { echo "FAIL"; exit 1; }
           echo "  $(git config --file ~/.gitconfig --get-regexp '^alias\.' | wc -l) git aliases loaded"
 
+      - name: Installer smoke test (bash 3.2)
+        run: /bin/bash ./scripts/test-install.sh
+
+      - name: Verify --check matches and detects drift
+        run: |
+          ./install.sh --check --no-packages
+          echo "# drift" >> ~/.gnu_aliases
+          if ./install.sh --check --no-packages; then
+            echo "FAIL: drift not detected"; exit 1
+          fi
+          echo "PASS: drift detected"
+
       - name: Collect evidence
         if: always()
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "private/skills"]
+	path = private/skills
+	url = git@github.com:woud420/skills.git

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all help install install-minimal install-no-packages install-dry-run install-copy install-git-hooks check test-install check-editor brew-sync clean-backup
+.PHONY: all help install install-minimal install-no-packages install-dry-run install-copy install-git-hooks check check-live test-install check-editor doctor backup brew-sync clean-backup
 .ONESHELL:
 
 SHELL		= /bin/bash
@@ -26,6 +26,15 @@ check: test-install
 	bash -n $(DOTFILE_DIR)/install.sh
 	bash -n $(DOTFILE_DIR)/scripts/check-editor-parity.sh
 	bash -n $(DOTFILE_DIR)/scripts/test-install.sh
+
+check-live:
+	$(DOTFILE_DIR)/install.sh --check
+
+doctor:
+	$(DOTFILE_DIR)/install.sh --doctor
+
+backup:
+	$(DOTFILE_DIR)/install.sh --backup-only
 
 test-install:
 	$(DOTFILE_DIR)/scripts/test-install.sh
@@ -63,11 +72,14 @@ help:
 	@echo ""
 	@echo "Checks:"
 	@echo "  make check              # Lint installer scripts + run smoke test"
+	@echo "  make check-live         # Compare managed live files with the repo"
 	@echo "  make test-install       # Run the installer against a temp HOME"
 	@echo "  make check-editor       # Verify vim/nvim behavior parity"
+	@echo "  make doctor             # Check runtime dependencies"
 	@echo ""
 	@echo "Maintenance:"
 	@echo "  make brew-sync          # Update Brewfile with current packages"
+	@echo "  make backup             # Back up managed live files without installing"
 	@echo "  make clean-backup       # Remove old backup directories (30+ days)"
 	@echo ""
 	@echo "Direct script usage:"

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ dotfiles/
 │   ├── arch/              # Arch Linux packages
 │   ├── fedora/            # Fedora/RHEL packages
 │   └── alpine/            # Alpine Linux packages
+├── private/
+│   └── skills/             # Private agent skillpack submodule
 └── install.sh             # Universal installer
 ```
 
@@ -88,6 +90,7 @@ dotfiles/
 | `.vim/coc-settings.json` | `~/.vim/` and `~/.config/nvim/` | CoC LSP settings (both editors) |
 | `scripts/sudo-askpass.sh` | `~/.local/bin/sudo-askpass` | GUI sudo prompt helper |
 | `linux/arch/firefox/*` | Active Firefox profile | Desktop-matched browser chrome and settings pages |
+| `private/skills` active profile | `~/.agents/skills/` | Git-tracked private agent skills |
 
 ### Shell Functions
 
@@ -279,6 +282,31 @@ The installer copies `common/ai-context/` files into place:
 only seeded when absent (an existing customized one is left alone).
 Machine state snapshots are generated on demand with
 `scripts/refresh-machine-state.sh`.
+
+### Private Agent Skills
+
+`private/skills` is a submodule pinned to a commit in the private
+`woud420/skills` repository. The public dotfiles repository exposes the SSH
+URL and pinned commit ID, but no private skill contents or credentials.
+
+On a normal install, `install.sh` initializes the submodule when needed and
+copies only Git-tracked skills marked `active` or `maintenance` in its
+`manifest.json` into `~/.agents/skills/`. Candidate skills, untracked files,
+and repository metadata are not installed. Existing managed files are covered
+by the normal backup and `--check` behavior; target-only skills are left alone.
+
+Initialization requires GitHub SSH access to the private repository. Public CI
+sets `DOTFILES_SKIP_PRIVATE_SKILLS=1` and never requests private credentials.
+The same variable can explicitly skip private skills on another machine.
+
+```bash
+# Initialize manually or repair an unavailable private checkout
+git submodule update --init --checkout -- private/skills
+
+# Advance the pinned skillpack revision intentionally
+git submodule update --remote --checkout -- private/skills
+git add private/skills
+```
 
 ## 📚 Requirements
 

--- a/README.md
+++ b/README.md
@@ -244,10 +244,11 @@ Machine-specific config lives outside the repo and survives reinstalls:
 - `~/.bashrc.local` / `~/.zshrc.local` - sourced at the end of the shell configs
 - `~/.gitconfig.local` - included last by `.gitconfig`, so identity or
   tool-specific settings win over the shared config
-- `~/.ssh/config` - your own host entries stay first; the shared defaults are
-  pulled in via `Include ~/.ssh/config.dotfiles`. Note the shared defaults set
-  `ForwardAgent yes` globally - convenient across personal machines, but scope
-  it per-host in a local block if you ssh to hosts you don't control.
+- `~/.ssh/config` - machine-specific host entries and identity files stay in
+  this local file; shared defaults are pulled in first via
+  `Include ~/.ssh/config.dotfiles`. OpenSSH keeps the first value it reads, so
+  change a shared scalar default such as `ForwardAgent` in `common/ssh/config`
+  rather than trying to override it in a later local host block.
 
 ### Personal Git Hooks
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Machine-specific config lives outside the repo and survives reinstalls:
 
 - `~/.bashrc.local` / `~/.zshrc.local` - sourced at the end of the shell configs
 - `~/.gitconfig.local` - included last by `.gitconfig`, so identity or
-  tool-appended blocks (e.g. git-ai) win over the shared config
+  tool-specific settings win over the shared config
 - `~/.ssh/config` - your own host entries stay first; the shared defaults are
   pulled in via `Include ~/.ssh/config.dotfiles`. Note the shared defaults set
   `ForwardAgent yes` globally - convenient across personal machines, but scope

--- a/README.md
+++ b/README.md
@@ -20,12 +20,18 @@ make install
 ./install.sh --minimal      # Minimal config for servers/containers
 ./install.sh --no-packages  # Skip package installation
 ./install.sh --dry-run      # Preview what will be installed
+./install.sh --check        # Compare managed live files with the repo
+./install.sh --backup-only  # Snapshot managed files without installing
+./install.sh --doctor       # Check runtime dependencies
 
 # Make targets
 make install              # Full installation
 make install-minimal      # Minimal config
 make install-no-packages  # Config files only
 make install-dry-run      # Preview changes
+make check-live           # Detect missing or changed managed files
+make backup               # Create a path-preserving live backup
+make doctor               # Check commands, portals, fonts, and themes
 ```
 
 ### Remote Installation
@@ -81,6 +87,7 @@ dotfiles/
 | `common/nvim/init.vim` | `~/.config/nvim/init.vim` | Neovim bridge to the Vim config |
 | `.vim/coc-settings.json` | `~/.vim/` and `~/.config/nvim/` | CoC LSP settings (both editors) |
 | `scripts/sudo-askpass.sh` | `~/.local/bin/sudo-askpass` | GUI sudo prompt helper |
+| `linux/arch/firefox/*` | Active Firefox profile | Desktop-matched browser chrome and settings pages |
 
 ### Shell Functions
 
@@ -171,6 +178,20 @@ The installer automatically backs up existing configs to:
 ~/.dotfiles-backup-YYYYMMDD_HHMMSS/
 ```
 
+Backups mirror home-directory paths under `files/` and include an
+`install-audit.tsv`. Create a snapshot without changing live files with:
+
+```bash
+make backup
+```
+
+Restore one file after inspecting a backup:
+
+```bash
+cp -a ~/.dotfiles-backup-YYYYMMDD_HHMMSS/files/.config/waybar/config \
+  ~/.config/waybar/config
+```
+
 To clean old backups (30+ days):
 ```bash
 make clean-backup
@@ -187,7 +208,13 @@ and distribution and installs the right layer on top of `common/`:
   overlays)
 
 Installs are always copies (never symlinks) with path-preserving backups and
-an audit log. Preview any run with `./install.sh --dry-run`.
+an audit log. Preview any run with `./install.sh --dry-run`, then use
+`./install.sh --check` to prove every managed live copy matches the repo.
+
+On Arch, the installer also discovers the active profile from Firefox's
+`profiles.ini` and installs the tracked `userChrome.css`, `userContent.css`,
+and `user.js`. Launch Firefox once before the first install so the profile
+exists, and restart Firefox after those files change.
 
 This converges personal interactive machines on Zsh, Kitty, and Neovim while
 keeping Bash available as a fallback. The history of this effort is recorded

--- a/common/git/.gitconfig
+++ b/common/git/.gitconfig
@@ -86,7 +86,7 @@
 	required = true
 [core]
 	hooksPath = ~/.config/git/hooks
-# Machine-local overrides (identity, tool-appended blocks like git-ai trace2).
+# Machine-local overrides (identity and tool-specific settings).
 # Values here win because git reads includes last.
 [include]
 	path = ~/.gitconfig.local

--- a/common/shell/.bashrc
+++ b/common/shell/.bashrc
@@ -154,7 +154,7 @@ path_prepend() {
 }
 
 path_prepend "/usr/local/bin" "/usr/local/sbin" "/opt/homebrew/bin" \
-    "$HOME/bin" "$HOME/.local/bin" "$HOME/.cargo/bin" "$HOME/.git-ai/bin"
+    "$HOME/bin" "$HOME/.local/bin" "$HOME/.cargo/bin"
 export PATH
 
 # Load custom shell functions

--- a/common/shell/.zshrc
+++ b/common/shell/.zshrc
@@ -130,7 +130,7 @@ path_prepend() {
   done
 }
 
-path_prepend "/opt/homebrew/bin" "/usr/local/bin" "/usr/local/sbin" "$HOME/bin" "$HOME/.local/bin" "$HOME/.cargo/bin" "$HOME/.git-ai/bin"
+path_prepend "/opt/homebrew/bin" "/usr/local/bin" "/usr/local/sbin" "$HOME/bin" "$HOME/.local/bin" "$HOME/.cargo/bin"
 
 # mise (version manager for Python, Node, etc.)
 if command -v mise >/dev/null 2>&1; then

--- a/common/ssh/config
+++ b/common/ssh/config
@@ -11,4 +11,3 @@ Host *
 Host github.com
   HostName github.com
   User git
-  IdentityFile ~/.ssh/github-id-rsa

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # ===== Universal Dotfiles Installer =====
 # Works on macOS, Linux (Ubuntu/Debian, Arch, RHEL/CentOS, Alpine)
-# Usage: ./install.sh [--minimal] [--no-packages] [--dry-run] [--copy]
+# Usage: ./install.sh [--minimal] [--no-packages] [--dry-run] [--check] [--backup-only] [--doctor]
 #
 # Installation Order:
 # 1. OS Detection & Environment Setup
@@ -301,17 +301,26 @@ install_arch_packages() {
     local packages=()
     local package
 
+    local queried=0 unavailable=0
     while IFS= read -r package; do
         [[ -n "$package" ]] || continue
         if pacman -Q "$package" >/dev/null 2>&1; then
             continue
         fi
+        queried=$((queried + 1))
         if pacman -Si "$package" >/dev/null 2>&1; then
             packages+=("$package")
         else
+            unavailable=$((unavailable + 1))
             log_warning "Skipping unavailable Arch package: $package"
         fi
     done < <(sed '/^[[:space:]]*#/d; /^[[:space:]]*$/d' "$package_list")
+
+    # Every queried package unknown almost certainly means the sync database
+    # is missing or stale, not that the whole list is invalid.
+    if [[ "$queried" -gt 0 && "$unavailable" -eq "$queried" ]]; then
+        log_error "No queried package exists in the pacman sync DB; run 'sudo pacman -Sy' and re-run the installer"
+    fi
 
     if [[ "${#packages[@]}" -eq 0 ]]; then
         log_info "Official Arch packages are already installed"
@@ -439,6 +448,34 @@ materialize_target_dir() {
     done
 }
 
+# Check-mode counterpart of materialize_target_dir: a symlinked ancestor into
+# the repo means install and check would disagree about this HOME.
+CHECKED_SYMLINK_ANCESTORS=""
+check_ancestor_symlinks() {
+    local seg="$1" repo_real resolved
+    repo_real="$(cd "$DOTFILES_DIR" 2>/dev/null && pwd -P || printf '%s' "$DOTFILES_DIR")"
+    while [[ "$seg" != "$HOME" && "$seg" != "/" && -n "$seg" ]]; do
+        if [[ -L "$seg" ]]; then
+            resolved="$(cd "$seg" 2>/dev/null && pwd -P || true)"
+            case "$resolved" in
+                "$repo_real"|"$repo_real"/*)
+                    # Report each offending ancestor once, not per managed file
+                    case "$CHECKED_SYMLINK_ANCESTORS" in
+                        *":$seg:"*) ;;
+                        *)
+                            CHECKED_SYMLINK_ANCESTORS="$CHECKED_SYMLINK_ANCESTORS:$seg:"
+                            log_error "Symlinked directory into the repo: $seg -> $resolved"
+                            CHECK_FAILURES=$((CHECK_FAILURES + 1))
+                            ;;
+                    esac
+                    return 0
+                    ;;
+            esac
+        fi
+        seg="$(dirname "$seg")"
+    done
+}
+
 # Install a regular copied file
 install_file() {
     local source="$1"
@@ -446,8 +483,17 @@ install_file() {
     local target_dir
     target_dir="$(dirname "$target")"
 
+    # git ls-files enumerations list tracked files even when deleted from the
+    # worktree; a missing source must not abort the install (set -e) or be
+    # misreported as target drift in check mode.
+    if [[ ! -f "$source" ]]; then
+        log_warning "Source missing (deleted from worktree?): $source"
+        return 0
+    fi
+
     if [[ "$CHECK_MODE" == "true" ]]; then
         CHECKED_FILES=$((CHECKED_FILES + 1))
+        check_ancestor_symlinks "$target_dir"
         if [[ -L "$target" ]]; then
             log_error "Symlink where a regular copy is required: $target"
             CHECK_FAILURES=$((CHECK_FAILURES + 1))
@@ -584,7 +630,7 @@ install_ssh_config() {
         chmod 700 "$HOME/.ssh"
         install_file "$src" "$HOME/.ssh/config.dotfiles"
         chmod 600 "$HOME/.ssh/config.dotfiles"
-        if [[ ! -f "$HOME/.ssh/config" ]] || ! grep -q 'config\.dotfiles' "$HOME/.ssh/config"; then
+        if [[ ! -f "$HOME/.ssh/config" ]] || ! grep -q '^[[:space:]]*Include[[:space:]].*config\.dotfiles' "$HOME/.ssh/config"; then
             backup_file "$HOME/.ssh/config"
             # Prepend: an Include after a Host block would only apply to that
             # host, and IgnoreUnknown must be parsed before any UseKeychain.
@@ -648,6 +694,13 @@ reload_running_kitty() {
 
     local kitty_pid="${KITTY_PID:-}"
     [[ "$kitty_pid" =~ ^[0-9]+$ ]] || return 0
+
+    # A stale KITTY_PID (tmux outliving kitty) could point at a reused PID;
+    # SIGUSR1's default disposition would terminate that process.
+    case "$(ps -p "$kitty_pid" -o comm= 2>/dev/null)" in
+        *kitty*) ;;
+        *) return 0 ;;
+    esac
 
     if kill -USR1 "$kitty_pid" 2>/dev/null; then
         log_success "Reloaded Kitty configuration"
@@ -715,7 +768,7 @@ desktop_config_files() {
     local desktop_root="$DOTFILES_DIR/linux/arch/.config"
     local rel
 
-    if git -C "$DOTFILES_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if [[ "$(git -C "$DOTFILES_DIR" rev-parse --show-toplevel 2>/dev/null)" == "$(cd "$DOTFILES_DIR" && pwd -P)" ]]; then
         while IFS= read -r -d '' rel; do
             printf '%s\0' "$DOTFILES_DIR/$rel"
         done < <(git -C "$DOTFILES_DIR" ls-files -z -- linux/arch/.config)
@@ -757,6 +810,9 @@ firefox_default_profile() {
     local profile_default="0"
     local fallback_path=""
     local fallback_relative="1"
+    local profile_count=0
+    local first_profile_path=""
+    local first_profile_relative="1"
     local line=""
 
     while IFS= read -r line || [[ -n "$line" ]]; do
@@ -780,9 +836,16 @@ firefox_default_profile() {
                 ;;
             Profile*:Path=*)
                 profile_path="${line#*=}"
+                profile_count=$((profile_count + 1))
+                if [[ -z "$first_profile_path" ]]; then
+                    first_profile_path="$profile_path"
+                fi
                 ;;
             Profile*:IsRelative=*)
                 profile_relative="${line#*=}"
+                if [[ "$profile_count" -eq 1 ]]; then
+                    first_profile_relative="$profile_relative"
+                fi
                 ;;
             Profile*:Default=*)
                 profile_default="${line#*=}"
@@ -802,6 +865,11 @@ firefox_default_profile() {
     elif [[ -n "$fallback_path" ]]; then
         selected="$fallback_path"
         relative="$fallback_relative"
+    elif [[ "$profile_count" -eq 1 && -n "$first_profile_path" ]]; then
+        # Legacy single-profile profiles.ini: no [Install] section and no
+        # Default=1 flag; Firefox itself treats the lone profile as default.
+        selected="$first_profile_path"
+        relative="$first_profile_relative"
     else
         return 1
     fi
@@ -1211,6 +1279,10 @@ install_private_skills() {
     while IFS= read -r skill_dir; do
         [[ -n "$skill_dir" ]] || continue
         while IFS= read -r -d '' relative; do
+            if [[ -L "$source/$relative" || ! -f "$source/$relative" ]]; then
+                log_warning "Skipping non-regular skill file: $relative"
+                continue
+            fi
             install_file "$source/$relative" "$HOME/.agents/skills/$relative"
         done < <(git -C "$source" ls-files -z -- "$skill_dir")
     done <<< "$skill_dirs"
@@ -1376,8 +1448,12 @@ main() {
     fi
 
     if [[ "$BACKUP_ONLY" == "true" ]]; then
-        log_success "Backed up $BACKED_UP_FILES live files to $BACKUP_DIR"
-        [[ -n "$AUDIT_LOG" ]] && log_info "Audit log: $AUDIT_LOG"
+        if [[ "$DRY_RUN" == "true" ]]; then
+            log_info "Dry run: no files were backed up (see the 'Would backup' lines above)"
+        else
+            log_success "Backed up $BACKED_UP_FILES live files to $BACKUP_DIR"
+            [[ -n "$AUDIT_LOG" ]] && log_info "Audit log: $AUDIT_LOG"
+        fi
         return 0
     fi
     

--- a/install.sh
+++ b/install.sh
@@ -49,6 +49,10 @@ CHECKED_FILES=0
 CHECK_FAILURES=0
 BACKED_UP_FILES=0
 DOCTOR_FAILURES=0
+SUDO_CMD=(sudo)
+if [[ -n "${SUDO_ASKPASS:-}" && -x "${SUDO_ASKPASS}" ]]; then
+    SUDO_CMD=(sudo -A)
+fi
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -289,7 +293,7 @@ install_arch_packages() {
     done < <(sed '/^[[:space:]]*#/d; /^[[:space:]]*$/d' "$package_list")
 
     if [[ "${#packages[@]}" -gt 0 ]]; then
-        sudo pacman -S --needed --noconfirm "${packages[@]}" \
+        "${SUDO_CMD[@]}" pacman -S --needed --noconfirm "${packages[@]}" \
             || log_warning "Some Arch packages failed to install"
     fi
 }
@@ -302,9 +306,9 @@ install_packages_linux() {
             package_list="$DOTFILES_DIR/linux/debian/packages.list"
             if [[ "$DRY_RUN" == "false" ]]; then
                 log_step "Updating package lists..."
-                sudo apt-get update
+                "${SUDO_CMD[@]}" apt-get update
                 log_step "Installing packages from $package_list..."
-                grep -v '^#' "$package_list" | grep -v '^$' | xargs sudo apt-get install -y
+                grep -v '^#' "$package_list" | grep -v '^$' | xargs "${SUDO_CMD[@]}" apt-get install -y
             else
                 log_info "Would run: apt-get update && install packages from $package_list"
             fi
@@ -325,9 +329,9 @@ install_packages_linux() {
             if [[ "$DRY_RUN" == "false" ]]; then
                 log_step "Installing packages from $package_list..."
                 if command -v dnf >/dev/null 2>&1; then
-                    grep -v '^#' "$package_list" | grep -v '^$' | xargs sudo dnf install -y
+                    grep -v '^#' "$package_list" | grep -v '^$' | xargs "${SUDO_CMD[@]}" dnf install -y
                 else
-                    grep -v '^#' "$package_list" | grep -v '^$' | xargs sudo yum install -y
+                    grep -v '^#' "$package_list" | grep -v '^$' | xargs "${SUDO_CMD[@]}" yum install -y
                 fi
             else
                 log_info "Would install packages from $package_list with yum/dnf"
@@ -337,7 +341,7 @@ install_packages_linux() {
             package_list="$DOTFILES_DIR/linux/alpine/packages.list"
             if [[ "$DRY_RUN" == "false" ]]; then
                 log_step "Installing packages from $package_list..."
-                grep -v '^#' "$package_list" | grep -v '^$' | xargs sudo apk add --no-cache
+                grep -v '^#' "$package_list" | grep -v '^$' | xargs "${SUDO_CMD[@]}" apk add --no-cache
             else
                 log_info "Would install packages from $package_list with apk"
             fi

--- a/install.sh
+++ b/install.sh
@@ -36,12 +36,19 @@ NC='\033[0m' # No Color
 
 # Configuration
 DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-BACKUP_DIR="$HOME/.dotfiles-backup-$(date +%Y%m%d_%H%M%S)"
+BACKUP_DIR="${DOTFILES_BACKUP_DIR:-$HOME/.dotfiles-backup-$(date +%Y%m%d_%H%M%S)}"
 AUDIT_LOG=""
 INSTALL_ARGS="$*"
 MINIMAL_MODE=false
 INSTALL_PACKAGES=true
 DRY_RUN=false
+CHECK_MODE=false
+BACKUP_ONLY=false
+DOCTOR_MODE=false
+CHECKED_FILES=0
+CHECK_FAILURES=0
+BACKED_UP_FILES=0
+DOCTOR_FAILURES=0
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -58,6 +65,21 @@ while [[ $# -gt 0 ]]; do
             DRY_RUN=true
             shift
             ;;
+        --check)
+            CHECK_MODE=true
+            INSTALL_PACKAGES=false
+            shift
+            ;;
+        --backup-only)
+            BACKUP_ONLY=true
+            INSTALL_PACKAGES=false
+            shift
+            ;;
+        --doctor)
+            DOCTOR_MODE=true
+            INSTALL_PACKAGES=false
+            shift
+            ;;
         --copy)
             # Historical no-op: copied files are now the only install mode.
             shift
@@ -67,6 +89,9 @@ while [[ $# -gt 0 ]]; do
             echo "  --minimal       Install minimal config (no fancy tools)"
             echo "  --no-packages   Skip package installation"
             echo "  --dry-run       Show what would be done without doing it"
+            echo "  --check         Compare managed live files with the repo"
+            echo "  --backup-only   Back up managed live files without installing"
+            echo "  --doctor        Check runtime dependencies for this machine"
             echo "  --copy          No-op; files are always copied"
             echo "  -h, --help      Show this help"
             exit 0
@@ -77,6 +102,15 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+mode_count=0
+[[ "$CHECK_MODE" == "true" ]] && mode_count=$((mode_count + 1))
+[[ "$BACKUP_ONLY" == "true" ]] && mode_count=$((mode_count + 1))
+[[ "$DOCTOR_MODE" == "true" ]] && mode_count=$((mode_count + 1))
+if [[ "$mode_count" -gt 1 ]]; then
+    echo "Choose only one of --check, --backup-only, or --doctor"
+    exit 1
+fi
 
 # Logging functions
 log_info() {
@@ -99,8 +133,12 @@ log_step() {
     echo -e "${PURPLE}[STEP]${NC} $1"
 }
 
+state_only_mode() {
+    [[ "$CHECK_MODE" == "true" || "$BACKUP_ONLY" == "true" ]]
+}
+
 init_audit() {
-    if [[ "$DRY_RUN" == "true" ]] || [[ -n "$AUDIT_LOG" ]]; then
+    if [[ "$DRY_RUN" == "true" ]] || [[ "$CHECK_MODE" == "true" ]] || [[ -n "$AUDIT_LOG" ]]; then
         return
     fi
 
@@ -121,7 +159,7 @@ audit_action() {
     local target="${3:-}"
     local detail="${4:-}"
 
-    if [[ "$DRY_RUN" == "true" ]]; then
+    if [[ "$DRY_RUN" == "true" ]] || [[ "$CHECK_MODE" == "true" ]]; then
         return
     fi
 
@@ -151,6 +189,7 @@ detect_os() {
         OS="macos"
         DISTRO="macos"
     elif [[ -f /etc/os-release ]]; then
+        # shellcheck disable=SC1091
         source /etc/os-release
         OS="linux"
         DISTRO="${ID,,}" # Convert to lowercase
@@ -169,6 +208,7 @@ detect_os() {
 }
 
 # Container/Environment Detection
+# shellcheck disable=SC2034
 detect_environment() {
     if [[ -f /.dockerenv ]] || [[ -n "$CONTAINER" ]]; then
         ENVIRONMENT="container"
@@ -206,6 +246,54 @@ install_packages_macos() {
     fi
 }
 
+install_arch_aur_packages() {
+    local package_list="$DOTFILES_DIR/linux/arch/packages-aur.list"
+    [[ -f "$package_list" ]] || return 0
+
+    local helper=""
+    local candidate
+    for candidate in yay paru; do
+        if command -v "$candidate" >/dev/null 2>&1; then
+            helper="$candidate"
+            break
+        fi
+    done
+
+    if [[ -z "$helper" ]]; then
+        log_warning "No AUR helper found; install packages from $package_list manually"
+        return 0
+    fi
+
+    if [[ "$DRY_RUN" == "false" ]]; then
+        log_step "Installing AUR packages from $package_list with $helper..."
+        sed '/^[[:space:]]*#/d; /^[[:space:]]*$/d' "$package_list" \
+            | xargs "$helper" -S --needed --noconfirm \
+            || log_warning "Some AUR packages failed to install"
+    else
+        log_info "Would install packages from $package_list with $helper"
+    fi
+}
+
+install_arch_packages() {
+    local package_list="$1"
+    local packages=()
+    local package
+
+    while IFS= read -r package; do
+        [[ -n "$package" ]] || continue
+        if pacman -Si "$package" >/dev/null 2>&1; then
+            packages+=("$package")
+        else
+            log_warning "Skipping unavailable Arch package: $package"
+        fi
+    done < <(sed '/^[[:space:]]*#/d; /^[[:space:]]*$/d' "$package_list")
+
+    if [[ "${#packages[@]}" -gt 0 ]]; then
+        sudo pacman -S --needed --noconfirm "${packages[@]}" \
+            || log_warning "Some Arch packages failed to install"
+    fi
+}
+
 install_packages_linux() {
     local package_list=""
 
@@ -225,10 +313,11 @@ install_packages_linux() {
             package_list="$DOTFILES_DIR/linux/arch/packages.list"
             if [[ "$DRY_RUN" == "false" ]]; then
                 log_step "Installing packages from $package_list..."
-                # Filter comments and empty lines, then install
-                grep -v '^#' "$package_list" | grep -v '^$' | xargs sudo pacman -S --needed --noconfirm || log_warning "Some packages failed to install"
+                install_arch_packages "$package_list"
+                install_arch_aur_packages
             else
                 log_info "Would install packages from $package_list with pacman"
+                install_arch_aur_packages
             fi
             ;;
         rhel|centos|fedora)
@@ -262,6 +351,7 @@ install_packages_linux() {
 # Backup existing files (path-preserving: mirrors directory structure under BACKUP_DIR)
 backup_file() {
     local file="$1"
+    [[ "$CHECK_MODE" == "true" ]] && return 0
     if [[ -f "$file" ]] || [[ -L "$file" ]]; then
         if [[ "$DRY_RUN" == "false" ]]; then
             local backup_path
@@ -271,6 +361,7 @@ backup_file() {
                 audit_action "backup-skip" "$file" "$backup_path" "existing backup retained"
             else
                 cp -a "$file" "$backup_path"
+                BACKED_UP_FILES=$((BACKED_UP_FILES + 1))
                 audit_action "backup" "$file" "$backup_path" "existing target preserved"
                 log_info "Backed up $file to $backup_path"
             fi
@@ -316,7 +407,31 @@ materialize_target_dir() {
 install_file() {
     local source="$1"
     local target="$2"
-    local target_dir="$(dirname "$target")"
+    local target_dir
+    target_dir="$(dirname "$target")"
+
+    if [[ "$CHECK_MODE" == "true" ]]; then
+        CHECKED_FILES=$((CHECKED_FILES + 1))
+        if [[ -L "$target" ]]; then
+            log_error "Symlink where a regular copy is required: $target"
+            CHECK_FAILURES=$((CHECK_FAILURES + 1))
+        elif [[ ! -f "$target" ]]; then
+            log_error "Missing: $target"
+            CHECK_FAILURES=$((CHECK_FAILURES + 1))
+        elif ! cmp -s "$source" "$target"; then
+            log_error "Changed: $target"
+            CHECK_FAILURES=$((CHECK_FAILURES + 1))
+        elif [[ -x "$source" && ! -x "$target" ]]; then
+            log_error "Not executable: $target"
+            CHECK_FAILURES=$((CHECK_FAILURES + 1))
+        fi
+        return 0
+    fi
+
+    if [[ "$BACKUP_ONLY" == "true" ]]; then
+        backup_file "$target"
+        return 0
+    fi
 
     if [[ "$DRY_RUN" == "false" ]]; then
         # Create target directory if it doesn't exist
@@ -389,7 +504,13 @@ install_git_hooks() {
         return
     fi
 
-    if [[ "$DRY_RUN" == "false" ]]; then
+    if state_only_mode; then
+        for hook_file in "$hooks_src"/*; do
+            if [[ -f "$hook_file" && "$(basename "$hook_file")" != "README.md" ]]; then
+                install_file "$hook_file" "$hooks_dest/$(basename "$hook_file")"
+            fi
+        done
+    elif [[ "$DRY_RUN" == "false" ]]; then
         mkdir -p "$hooks_dest"
         for hook_file in "$hooks_src"/*; do
             if [[ -f "$hook_file" && "$(basename "$hook_file")" != "README.md" ]]; then
@@ -412,7 +533,16 @@ install_ssh_config() {
     [[ -f "$src" ]] || return 0
 
     log_step "Installing shared SSH config..."
-    if [[ "$DRY_RUN" == "false" ]]; then
+    if [[ "$CHECK_MODE" == "true" ]]; then
+        install_file "$src" "$HOME/.ssh/config.dotfiles"
+        if [[ ! -f "$HOME/.ssh/config" ]] || ! grep -q '^[[:space:]]*Include[[:space:]].*config\.dotfiles' "$HOME/.ssh/config"; then
+            log_error "Missing Include for ~/.ssh/config.dotfiles in ~/.ssh/config"
+            CHECK_FAILURES=$((CHECK_FAILURES + 1))
+        fi
+    elif [[ "$BACKUP_ONLY" == "true" ]]; then
+        backup_file "$HOME/.ssh/config"
+        install_file "$src" "$HOME/.ssh/config.dotfiles"
+    elif [[ "$DRY_RUN" == "false" ]]; then
         mkdir -p "$HOME/.ssh"
         chmod 700 "$HOME/.ssh"
         install_file "$src" "$HOME/.ssh/config.dotfiles"
@@ -438,7 +568,13 @@ install_ssh_config() {
 install_shell_functions() {
     log_step "Installing shell functions..."
 
-    if [[ "$DRY_RUN" == "false" ]]; then
+    if state_only_mode; then
+        for func_file in "$DOTFILES_DIR/common/shell-functions/"*.sh; do
+            if [[ -f "$func_file" ]]; then
+                install_file "$func_file" "$HOME/.config/shell-functions/$(basename "$func_file")"
+            fi
+        done
+    elif [[ "$DRY_RUN" == "false" ]]; then
         mkdir -p "$HOME/.config/shell-functions"
         for func_file in "$DOTFILES_DIR/common/shell-functions/"*.sh; do
             if [[ -f "$func_file" ]]; then
@@ -456,6 +592,8 @@ install_shell_functions() {
     # GUI sudo askpass helper at a stable path (sudo.sh points SUDO_ASKPASS here)
     if [[ "$MINIMAL_MODE" == "true" ]]; then
         log_info "Minimal mode: skipping sudo-askpass helper"
+    elif state_only_mode; then
+        install_file "$DOTFILES_DIR/scripts/sudo-askpass.sh" "$HOME/.local/bin/sudo-askpass"
     elif [[ "$DRY_RUN" == "false" ]]; then
         install_file "$DOTFILES_DIR/scripts/sudo-askpass.sh" "$HOME/.local/bin/sudo-askpass"
         chmod +x "$HOME/.local/bin/sudo-askpass"
@@ -469,11 +607,11 @@ install_terminal_config() {
     log_step "Installing terminal configuration..."
 
     # Kitty config based on OS (using hard copies for kitty to work properly)
-    if [[ "$DRY_RUN" == "false" ]]; then
+    if [[ "$DRY_RUN" == "false" ]] && ! state_only_mode; then
         audit_action "mkdir" "" "$HOME/.config/kitty" "ensure kitty config directory"
     fi
     
-    if [[ "$DRY_RUN" == "false" ]]; then
+    if [[ "$DRY_RUN" == "false" ]] || state_only_mode; then
         if [[ "$OS" == "macos" ]]; then
             install_file "$DOTFILES_DIR/darwin/kitty.conf" "$HOME/.config/kitty/kitty.conf"
         else
@@ -483,6 +621,10 @@ install_terminal_config() {
         # Copy themes
         for theme_file in "$DOTFILES_DIR/common/themes/"*.conf; do
             if [[ -f "$theme_file" ]]; then
+                if [[ ( "$DISTRO" == "arch" || "$DISTRO" == "manjaro" ) \
+                    && -f "$DOTFILES_DIR/linux/arch/.config/kitty/$(basename "$theme_file")" ]]; then
+                    continue
+                fi
                 install_file "$theme_file" "$HOME/.config/kitty/$(basename "$theme_file")"
             fi
         done
@@ -513,6 +655,23 @@ install_terminal_config() {
 # Install Linux desktop configurations (sway, waybar, gtk, rofi, mako, ...)
 # Copies everything under linux/arch/.config/ into ~/.config/ preserving
 # relative paths, so new tool configs are picked up without listing them here.
+desktop_config_files() {
+    local desktop_root="$DOTFILES_DIR/linux/arch/.config"
+    local rel
+
+    if git -C "$DOTFILES_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        while IFS= read -r -d '' rel; do
+            printf '%s\0' "$DOTFILES_DIR/$rel"
+        done < <(git -C "$DOTFILES_DIR" ls-files -z -- linux/arch/.config)
+    else
+        find "$desktop_root" -type f \
+            ! -path '*/__pycache__/*' \
+            ! -name '*.pyc' \
+            -print0 \
+            | sort -z
+    fi
+}
+
 install_desktop_configs() {
     if [[ "$DISTRO" != "arch" && "$DISTRO" != "manjaro" ]] || [[ "$MINIMAL_MODE" == "true" ]]; then
         return 0
@@ -523,11 +682,112 @@ install_desktop_configs() {
     local desktop_root="$DOTFILES_DIR/linux/arch/.config"
     local src rel
     while IFS= read -r -d '' src; do
-        rel="${src#$desktop_root/}"
+        rel="${src#"$desktop_root"/}"
         # kitty files are applied as theme overlays by install_terminal_config
         [[ "$rel" == kitty/* ]] && continue
         install_file "$src" "$HOME/.config/$rel"
-    done < <(find "$desktop_root" -type f -print0 | sort -z)
+    done < <(desktop_config_files)
+}
+
+firefox_default_profile() {
+    local firefox_root="$HOME/.mozilla/firefox"
+    local profiles_ini="$firefox_root/profiles.ini"
+    [[ -f "$profiles_ini" ]] || return 1
+
+    local section=""
+    local install_default=""
+    local profile_path=""
+    local profile_relative="1"
+    local profile_default="0"
+    local fallback_path=""
+    local fallback_relative="1"
+    local line=""
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line="${line%$'\r'}"
+        if [[ "$line" == \[*\] ]]; then
+            if [[ "$section" == Profile* && "$profile_default" == "1" && -n "$profile_path" && -z "$fallback_path" ]]; then
+                fallback_path="$profile_path"
+                fallback_relative="$profile_relative"
+            fi
+            section="${line#[}"
+            section="${section%]}"
+            profile_path=""
+            profile_relative="1"
+            profile_default="0"
+            continue
+        fi
+
+        case "$section:$line" in
+            Install*:Default=*)
+                install_default="${line#*=}"
+                ;;
+            Profile*:Path=*)
+                profile_path="${line#*=}"
+                ;;
+            Profile*:IsRelative=*)
+                profile_relative="${line#*=}"
+                ;;
+            Profile*:Default=*)
+                profile_default="${line#*=}"
+                ;;
+        esac
+    done < "$profiles_ini"
+
+    if [[ "$section" == Profile* && "$profile_default" == "1" && -n "$profile_path" && -z "$fallback_path" ]]; then
+        fallback_path="$profile_path"
+        fallback_relative="$profile_relative"
+    fi
+
+    local selected=""
+    local relative="1"
+    if [[ -n "$install_default" ]]; then
+        selected="$install_default"
+    elif [[ -n "$fallback_path" ]]; then
+        selected="$fallback_path"
+        relative="$fallback_relative"
+    else
+        return 1
+    fi
+
+    local resolved="$selected"
+    if [[ "$relative" != "0" && "$selected" != /* ]]; then
+        resolved="$firefox_root/$selected"
+    fi
+
+    if [[ ! -d "$resolved" && -n "$fallback_path" && "$selected" != "$fallback_path" ]]; then
+        selected="$fallback_path"
+        resolved="$selected"
+        if [[ "$fallback_relative" != "0" && "$selected" != /* ]]; then
+            resolved="$firefox_root/$selected"
+        fi
+    fi
+
+    [[ -d "$resolved" ]] || return 1
+    printf '%s\n' "$resolved"
+}
+
+install_firefox_config() {
+    if [[ "$DISTRO" != "arch" && "$DISTRO" != "manjaro" ]] || [[ "$MINIMAL_MODE" == "true" ]]; then
+        return 0
+    fi
+
+    local profile=""
+    if ! profile="$(firefox_default_profile)"; then
+        if [[ "$CHECK_MODE" == "true" ]]; then
+            log_error "Firefox profile not found; launch Firefox once, then rerun the installer"
+            CHECK_FAILURES=$((CHECK_FAILURES + 1))
+        else
+            log_warning "Firefox profile not found; launch Firefox once, then rerun the installer"
+        fi
+        return 0
+    fi
+
+    log_step "Installing Firefox profile theme..."
+    local firefox_src="$DOTFILES_DIR/linux/arch/firefox"
+    install_file "$firefox_src/user.js" "$profile/user.js"
+    install_file "$firefox_src/chrome/userChrome.css" "$profile/chrome/userChrome.css"
+    install_file "$firefox_src/chrome/userContent.css" "$profile/chrome/userContent.css"
 }
 
 # Compile CoC.nvim after plugin installation (shared by vim + nvim paths)
@@ -570,7 +830,7 @@ compile_coc_nvim() {
 install_vim_config() {
     log_step "Installing vim configuration..."
 
-    if [[ "$DRY_RUN" == "false" ]]; then
+    if [[ "$DRY_RUN" == "false" ]] && ! state_only_mode; then
         mkdir -p "$HOME/.vim/settings"
     fi
 
@@ -586,6 +846,10 @@ install_vim_config() {
             install_file "$settings_file" "$HOME/.vim/settings/$(basename "$settings_file")"
         fi
     done
+
+    if state_only_mode; then
+        return 0
+    fi
 
     if [[ "$MINIMAL_MODE" == "true" ]]; then
         log_info "Minimal mode: skipping vim plugin installation"
@@ -649,6 +913,7 @@ run_vim_in_pty() {
 report_plug_count() {
     local expected installed
     expected="$(grep -c "^Plug '" "$HOME/.vim/plugins.vim" 2>/dev/null || echo 0)"
+    # shellcheck disable=SC2012
     installed="$(ls -1 "$HOME/.vim/plugged" 2>/dev/null | wc -l | tr -d ' ')"
     if [[ "$installed" -ge "$expected" && "$expected" -gt 0 ]]; then
         log_success "vim plugins installed ($installed/$expected)"
@@ -661,7 +926,11 @@ report_plug_count() {
 install_neovim_config() {
     log_step "Installing neovim configuration..."
 
-    if [[ "$DRY_RUN" == "false" ]]; then
+    if state_only_mode; then
+        install_file "$DOTFILES_DIR/common/nvim/init.vim" "$HOME/.config/nvim/init.vim"
+        install_file "$DOTFILES_DIR/.vim/coc-settings.json" "$HOME/.config/nvim/coc-settings.json"
+        return 0
+    elif [[ "$DRY_RUN" == "false" ]]; then
         mkdir -p "$HOME/.config/nvim"
 
         backup_file "$HOME/.config/nvim/init.vim"
@@ -697,6 +966,10 @@ install_neovim_config() {
 
 # Install optional tools
 install_optional_tools() {
+    if state_only_mode; then
+        return 0
+    fi
+
     if [[ "$MINIMAL_MODE" == "true" ]]; then
         log_info "Minimal mode: Skipping optional tools"
         return
@@ -732,7 +1005,9 @@ install_ai_context() {
     # only seed it when absent instead of clobbering it on every install.
     local claude_src="$DOTFILES_DIR/common/ai-context/CLAUDE.md"
     if [[ -f "$claude_src" ]]; then
-        if [[ -f "$HOME/.claude/CLAUDE.md" ]] && ! cmp -s "$claude_src" "$HOME/.claude/CLAUDE.md"; then
+        if [[ "$BACKUP_ONLY" == "true" ]]; then
+            backup_file "$HOME/.claude/CLAUDE.md"
+        elif [[ -f "$HOME/.claude/CLAUDE.md" ]] && ! cmp -s "$claude_src" "$HOME/.claude/CLAUDE.md"; then
             log_info "Keeping existing ~/.claude/CLAUDE.md (differs from repo version; merge manually if wanted)"
         else
             install_file "$claude_src" "$HOME/.claude/CLAUDE.md"
@@ -773,6 +1048,102 @@ install_ai_context() {
     # DOTFILES_DIR=$DOTFILES_DIR scripts/refresh-machine-state.sh
 }
 
+backup_local_overrides() {
+    [[ "$BACKUP_ONLY" == "true" ]] || return 0
+
+    local file
+    for file in \
+        "$HOME/.bashrc.local" \
+        "$HOME/.zshrc.local" \
+        "$HOME/.gitconfig.local" \
+        "$HOME/.ssh/config"; do
+        backup_file "$file"
+    done
+}
+
+doctor_require_command() {
+    local command="$1"
+    if command -v "$command" >/dev/null 2>&1; then
+        log_success "$command"
+    else
+        log_error "Missing command: $command"
+        DOCTOR_FAILURES=$((DOCTOR_FAILURES + 1))
+    fi
+}
+
+doctor_require_path() {
+    local path="$1"
+    local description="$2"
+    if [[ -e "$path" ]]; then
+        log_success "$description"
+    else
+        log_error "Missing $description: $path"
+        DOCTOR_FAILURES=$((DOCTOR_FAILURES + 1))
+    fi
+}
+
+doctor_optional_command() {
+    local command="$1"
+    if command -v "$command" >/dev/null 2>&1; then
+        log_success "$command (optional)"
+    else
+        log_warning "Optional command not found: $command"
+    fi
+}
+
+run_doctor() {
+    log_step "Checking runtime dependencies..."
+
+    local command
+    local common_commands=(bash git zsh kitty nvim rg fzf)
+    for command in "${common_commands[@]}"; do
+        doctor_require_command "$command"
+    done
+
+    if [[ "$DISTRO" == "arch" || "$DISTRO" == "manjaro" ]]; then
+        local desktop_commands=(
+            sway waybar rofi mako grim slurp wl-copy cliphist playerctl
+            thunar ranger pavucontrol notify-send nmcli pactl firefox
+            spotify slack steam
+        )
+        for command in "${desktop_commands[@]}"; do
+            doctor_require_command "$command"
+        done
+
+        doctor_require_path "/usr/lib/xdg-desktop-portal" "desktop portal"
+        doctor_require_path "/usr/lib/xdg-desktop-portal-gtk" "GTK portal backend"
+        doctor_require_path "/usr/lib/xdg-desktop-portal-wlr" "wlroots portal backend"
+        doctor_require_path "/usr/share/themes/Nordic-darker" "Nordic-darker GTK theme"
+
+        if command -v fc-list >/dev/null 2>&1 && fc-list -q "FiraCode Nerd Font"; then
+            log_success "FiraCode Nerd Font"
+        else
+            log_error "Missing FiraCode Nerd Font"
+            DOCTOR_FAILURES=$((DOCTOR_FAILURES + 1))
+        fi
+
+        if command -v sway >/dev/null 2>&1 && sway --version 2>/dev/null | grep -qi swayfx; then
+            log_success "SwayFX runtime"
+        else
+            log_error "SwayFX is required by the committed Sway effects"
+            DOCTOR_FAILURES=$((DOCTOR_FAILURES + 1))
+        fi
+
+        doctor_optional_command docker
+        doctor_optional_command kubectl
+        if [[ ! -f "$HOME/.config/waybar/modules/mailsecrets.py" ]]; then
+            log_warning "Waybar mail counter is disabled until mailsecrets.py exists"
+        fi
+    fi
+
+    if [[ "$DOCTOR_FAILURES" -gt 0 ]]; then
+        log_error "Doctor found $DOCTOR_FAILURES missing required component(s)"
+        return 1
+    fi
+
+    log_success "Runtime dependencies are present"
+}
+
 # Main installation function
 main() {
     echo -e "${CYAN}"
@@ -784,6 +1155,11 @@ main() {
 
     detect_os
     detect_environment
+
+    if [[ "$DOCTOR_MODE" == "true" ]]; then
+        run_doctor
+        return
+    fi
 
     if [[ "$DRY_RUN" == "true" ]]; then
         log_warning "DRY RUN MODE - No changes will be made"
@@ -814,10 +1190,27 @@ main() {
     install_shell_functions     # 3. Shell functions (depends on shell configs)
     install_terminal_config     # 4. Terminal configs (kitty, htop)
     install_desktop_configs     # 5. Linux desktop configs (sway/waybar/gtk) - arch only
-    install_vim_config          # 6. Vim setup (plugins, settings, CoC compilation)
-    install_neovim_config       # 7. Neovim bridge to Vim config
-    install_optional_tools      # 8. Optional tools (fzf, etc.) - last
-    install_ai_context          # 9. AI context files (CLAUDE.md, AGENTS.md, MACHINE.md)
+    install_firefox_config      # 6. Firefox profile chrome/content theme - arch only
+    install_vim_config          # 7. Vim setup (plugins, settings, CoC compilation)
+    install_neovim_config       # 8. Neovim bridge to Vim config
+    install_optional_tools      # 9. Optional tools (fzf, etc.) - last
+    install_ai_context          # 10. AI context files (CLAUDE.md, AGENTS.md, MACHINE.md)
+    backup_local_overrides
+
+    if [[ "$CHECK_MODE" == "true" ]]; then
+        if [[ "$CHECK_FAILURES" -gt 0 ]]; then
+            log_error "$CHECK_FAILURES of $CHECKED_FILES managed files or requirements differ"
+            return 1
+        fi
+        log_success "All $CHECKED_FILES managed files match the repo"
+        return 0
+    fi
+
+    if [[ "$BACKUP_ONLY" == "true" ]]; then
+        log_success "Backed up $BACKED_UP_FILES live files to $BACKUP_DIR"
+        [[ -n "$AUDIT_LOG" ]] && log_info "Audit log: $AUDIT_LOG"
+        return 0
+    fi
     
     echo -e "${GREEN}"
     echo "╔══════════════════════════════════════════════════════════════╗"

--- a/install.sh
+++ b/install.sh
@@ -254,6 +254,20 @@ install_arch_aur_packages() {
     local package_list="$DOTFILES_DIR/linux/arch/packages-aur.list"
     [[ -f "$package_list" ]] || return 0
 
+    local packages=()
+    local package
+    while IFS= read -r package; do
+        [[ -n "$package" ]] || continue
+        if ! pacman -Q "$package" >/dev/null 2>&1; then
+            packages+=("$package")
+        fi
+    done < <(sed '/^[[:space:]]*#/d; /^[[:space:]]*$/d' "$package_list")
+
+    if [[ "${#packages[@]}" -eq 0 ]]; then
+        log_info "AUR packages are already installed"
+        return 0
+    fi
+
     local helper=""
     local candidate
     for candidate in yay paru; do
@@ -269,12 +283,11 @@ install_arch_aur_packages() {
     fi
 
     if [[ "$DRY_RUN" == "false" ]]; then
-        log_step "Installing AUR packages from $package_list with $helper..."
-        sed '/^[[:space:]]*#/d; /^[[:space:]]*$/d' "$package_list" \
-            | xargs "$helper" -S --needed --noconfirm \
+        log_step "Installing missing AUR packages from $package_list with $helper..."
+        "$helper" -S --needed --noconfirm "${packages[@]}" \
             || log_warning "Some AUR packages failed to install"
     else
-        log_info "Would install packages from $package_list with $helper"
+        log_info "Would install ${#packages[@]} missing packages from $package_list with $helper"
     fi
 }
 
@@ -285,6 +298,9 @@ install_arch_packages() {
 
     while IFS= read -r package; do
         [[ -n "$package" ]] || continue
+        if pacman -Q "$package" >/dev/null 2>&1; then
+            continue
+        fi
         if pacman -Si "$package" >/dev/null 2>&1; then
             packages+=("$package")
         else
@@ -292,10 +308,21 @@ install_arch_packages() {
         fi
     done < <(sed '/^[[:space:]]*#/d; /^[[:space:]]*$/d' "$package_list")
 
-    if [[ "${#packages[@]}" -gt 0 ]]; then
-        "${SUDO_CMD[@]}" pacman -S --needed --noconfirm "${packages[@]}" \
-            || log_warning "Some Arch packages failed to install"
+    if [[ "${#packages[@]}" -eq 0 ]]; then
+        log_info "Official Arch packages are already installed"
+        return 0
     fi
+
+    if "${SUDO_CMD[@]}" pacman -S --needed --noconfirm "${packages[@]}"; then
+        return 0
+    fi
+
+    log_warning "Batch install failed; retrying missing packages individually"
+    for package in "${packages[@]}"; do
+        pacman -Q "$package" >/dev/null 2>&1 && continue
+        "${SUDO_CMD[@]}" pacman -S --needed --noconfirm "$package" \
+            || log_warning "Failed to install Arch package: $package"
+    done
 }
 
 install_packages_linux() {

--- a/install.sh
+++ b/install.sh
@@ -633,6 +633,24 @@ install_shell_functions() {
     fi
 }
 
+# Kitty watches its config files, but install_file replaces them one at a time.
+# Force one final reload after the complete config and theme set is present.
+reload_running_kitty() {
+    if [[ "$DRY_RUN" == "true" ]] || state_only_mode \
+        || [[ "${DOTFILES_NO_RUNTIME_RELOAD:-0}" == "1" ]]; then
+        return 0
+    fi
+
+    local kitty_pid="${KITTY_PID:-}"
+    [[ "$kitty_pid" =~ ^[0-9]+$ ]] || return 0
+
+    if kill -USR1 "$kitty_pid" 2>/dev/null; then
+        log_success "Reloaded Kitty configuration"
+    else
+        log_warning "Could not reload Kitty process $kitty_pid; press Ctrl+Shift+F5 in Kitty"
+    fi
+}
+
 # Install terminal configuration
 install_terminal_config() {
     log_step "Installing terminal configuration..."
@@ -667,6 +685,8 @@ install_terminal_config() {
                 install_file "$theme_file" "$HOME/.config/kitty/$(basename "$theme_file")"
             done
         fi
+
+        reload_running_kitty
     else
         if [[ "$OS" == "macos" ]]; then
             log_info "Would copy: darwin/kitty.conf -> ~/.config/kitty/kitty.conf"

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,7 @@
 #    - Vim/Neovim setup (plugins, CoC compilation)
 #    - Optional tools (fzf, etc.)
 #    - AI context files (CLAUDE.md, AGENTS.md, MACHINE.md)
+#    - Private agent skills (when the authenticated submodule is available)
 #
 # Features:
 # - Auto-detects OS and environment (local/remote/container)
@@ -1103,6 +1104,118 @@ install_ai_context() {
     # DOTFILES_DIR=$DOTFILES_DIR scripts/refresh-machine-state.sh
 }
 
+private_skill_dirs() {
+    local manifest="$1"
+    python3 - "$manifest" <<'PY'
+import json
+import sys
+from pathlib import PurePosixPath
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    manifest = json.load(handle)
+
+seen = set()
+for skill in manifest.get("skills", []):
+    if skill.get("status") not in {"active", "maintenance"}:
+        continue
+    path = PurePosixPath(skill.get("path", ""))
+    if path.is_absolute() or ".." in path.parts or path.name != "SKILL.md" or len(path.parts) < 2:
+        raise SystemExit(f"invalid skill path in manifest: {path}")
+    directory = str(path.parent)
+    if directory not in seen:
+        print(directory)
+        seen.add(directory)
+PY
+}
+
+prepare_private_skills_source() {
+    local source="$DOTFILES_DIR/private/skills"
+
+    if [[ "${DOTFILES_SKIP_PRIVATE_SKILLS:-0}" == "1" ]]; then
+        log_info "Skipping private agent skills"
+        return 1
+    fi
+
+    if [[ -e "$source/.git" && -f "$source/manifest.json" ]]; then
+        return 0
+    fi
+
+    if [[ -n "${CI:-}" ]]; then
+        log_info "Private skills submodule is unavailable in public CI; skipping"
+        return 1
+    fi
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "Would initialize private/skills and install active skills into ~/.agents/skills"
+        return 1
+    fi
+
+    if state_only_mode; then
+        if [[ "$CHECK_MODE" == "true" ]]; then
+            log_error "Private skills submodule is not initialized; run: git submodule update --init -- private/skills"
+            CHECK_FAILURES=$((CHECK_FAILURES + 1))
+        else
+            log_warning "Private skills submodule is not initialized; private skills were not backed up"
+        fi
+        return 1
+    fi
+
+    log_step "Initializing private skills submodule..."
+    if ! git -C "$DOTFILES_DIR" submodule update --init --checkout -- private/skills; then
+        log_warning "Could not initialize private skills; verify GitHub SSH access to woud420/skills"
+        return 1
+    fi
+
+    if [[ ! -e "$source/.git" || ! -f "$source/manifest.json" ]]; then
+        log_warning "Private skills submodule initialized without a usable manifest"
+        return 1
+    fi
+
+    return 0
+}
+
+install_private_skills() {
+    if [[ "$MINIMAL_MODE" == "true" ]]; then
+        log_info "Minimal mode: skipping private agent skills"
+        return 0
+    fi
+
+    if ! prepare_private_skills_source; then
+        return 0
+    fi
+
+    if ! command -v python3 >/dev/null 2>&1; then
+        if [[ "$CHECK_MODE" == "true" ]]; then
+            log_error "python3 is required to read the private skills manifest"
+            CHECK_FAILURES=$((CHECK_FAILURES + 1))
+        else
+            log_warning "python3 is required to install private agent skills"
+        fi
+        return 0
+    fi
+
+    local source="$DOTFILES_DIR/private/skills"
+    local skill_dirs
+    if ! skill_dirs="$(private_skill_dirs "$source/manifest.json")"; then
+        if [[ "$CHECK_MODE" == "true" ]]; then
+            log_error "Private skills manifest is invalid"
+            CHECK_FAILURES=$((CHECK_FAILURES + 1))
+        else
+            log_warning "Private skills manifest is invalid; skipping"
+        fi
+        return 0
+    fi
+
+    log_step "Installing active private agent skills..."
+    local skill_dir relative
+    while IFS= read -r skill_dir; do
+        [[ -n "$skill_dir" ]] || continue
+        while IFS= read -r -d '' relative; do
+            install_file "$source/$relative" "$HOME/.agents/skills/$relative"
+        done < <(git -C "$source" ls-files -z -- "$skill_dir")
+    done <<< "$skill_dirs"
+}
+
 backup_local_overrides() {
     [[ "$BACKUP_ONLY" == "true" ]] || return 0
 
@@ -1250,6 +1363,7 @@ main() {
     install_neovim_config       # 8. Neovim bridge to Vim config
     install_optional_tools      # 9. Optional tools (fzf, etc.) - last
     install_ai_context          # 10. AI context files (CLAUDE.md, AGENTS.md, MACHINE.md)
+    install_private_skills      # 11. Active skills from the authenticated private submodule
     backup_local_overrides
 
     if [[ "$CHECK_MODE" == "true" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -141,6 +141,10 @@ state_only_mode() {
     [[ "$CHECK_MODE" == "true" || "$BACKUP_ONLY" == "true" ]]
 }
 
+is_arch_family() {
+    [[ "$DISTRO" == "arch" || "$DISTRO" == "manjaro" ]]
+}
+
 init_audit() {
     if [[ "$DRY_RUN" == "true" ]] || [[ "$CHECK_MODE" == "true" ]] || [[ -n "$AUDIT_LOG" ]]; then
         return
@@ -556,9 +560,10 @@ install_git_hooks() {
     fi
 }
 
-# Install shared SSH config without clobbering machine-local host entries:
-# the shared file lands at ~/.ssh/config.dotfiles and is Include'd from
-# ~/.ssh/config, so per-machine hosts keep precedence.
+# Install shared SSH config without replacing machine-local host entries:
+# the shared file lands at ~/.ssh/config.dotfiles and is included before the
+# existing ~/.ssh/config content. Shared scalar defaults therefore win under
+# OpenSSH's first-value semantics; identity files remain machine-local.
 install_ssh_config() {
     local src="$DOTFILES_DIR/common/ssh/config"
     [[ -f "$src" ]] || return 0
@@ -636,8 +641,7 @@ install_shell_functions() {
 # Kitty watches its config files, but install_file replaces them one at a time.
 # Force one final reload after the complete config and theme set is present.
 reload_running_kitty() {
-    if [[ "$DRY_RUN" == "true" ]] || state_only_mode \
-        || [[ "${DOTFILES_NO_RUNTIME_RELOAD:-0}" == "1" ]]; then
+    if [[ "$DRY_RUN" == "true" ]] || state_only_mode; then
         return 0
     fi
 
@@ -670,8 +674,8 @@ install_terminal_config() {
         # Copy themes
         for theme_file in "$DOTFILES_DIR/common/themes/"*.conf; do
             if [[ -f "$theme_file" ]]; then
-                if [[ ( "$DISTRO" == "arch" || "$DISTRO" == "manjaro" ) \
-                    && -f "$DOTFILES_DIR/linux/arch/.config/kitty/$(basename "$theme_file")" ]]; then
+                if is_arch_family \
+                    && [[ -f "$DOTFILES_DIR/linux/arch/.config/kitty/$(basename "$theme_file")" ]]; then
                     continue
                 fi
                 install_file "$theme_file" "$HOME/.config/kitty/$(basename "$theme_file")"
@@ -679,7 +683,7 @@ install_terminal_config() {
         done
 
         # Arch-specific theme overrides (e.g. personal-pink plum background)
-        if [[ "$DISTRO" == "arch" || "$DISTRO" == "manjaro" ]]; then
+        if is_arch_family; then
             for theme_file in "$DOTFILES_DIR/linux/arch/.config/kitty/"*.conf; do
                 [[ -f "$theme_file" ]] || continue
                 install_file "$theme_file" "$HOME/.config/kitty/$(basename "$theme_file")"
@@ -694,7 +698,7 @@ install_terminal_config() {
             log_info "Would copy: linux/common/kitty.conf -> ~/.config/kitty/kitty.conf"
         fi
         log_info "Would copy kitty themes to ~/.config/kitty/"
-        if [[ "$DISTRO" == "arch" || "$DISTRO" == "manjaro" ]]; then
+        if is_arch_family; then
             log_info "Would apply Arch kitty overrides from linux/arch/.config/kitty/ to ~/.config/kitty/"
         fi
     fi
@@ -724,7 +728,7 @@ desktop_config_files() {
 }
 
 install_desktop_configs() {
-    if [[ "$DISTRO" != "arch" && "$DISTRO" != "manjaro" ]] || [[ "$MINIMAL_MODE" == "true" ]]; then
+    if ! is_arch_family || [[ "$MINIMAL_MODE" == "true" ]]; then
         return 0
     fi
 
@@ -819,7 +823,7 @@ firefox_default_profile() {
 }
 
 install_firefox_config() {
-    if [[ "$DISTRO" != "arch" && "$DISTRO" != "manjaro" ]] || [[ "$MINIMAL_MODE" == "true" ]]; then
+    if ! is_arch_family || [[ "$MINIMAL_MODE" == "true" ]]; then
         return 0
     fi
 
@@ -1151,7 +1155,7 @@ run_doctor() {
         doctor_require_command "$command"
     done
 
-    if [[ "$DISTRO" == "arch" || "$DISTRO" == "manjaro" ]]; then
+    if is_arch_family; then
         local desktop_commands=(
             sway waybar rofi mako grim slurp wl-copy cliphist playerctl
             thunar ranger pavucontrol notify-send nmcli pactl firefox

--- a/linux/arch/.config/waybar/config
+++ b/linux/arch/.config/waybar/config
@@ -87,10 +87,6 @@
         "on-click": "steam",
         "tooltip": false
     },
-    "custom/launch-thunderbird": {
-        "format":  "<span font='14'></span>",
-        "on-click": "thunderbird"
-    },
     "pulseaudio": {
         "format": "{icon}",
         "format-alt": "{volume} {icon}",
@@ -143,6 +139,7 @@
         "interval": 60,
         "return-type": "json",
         "exec": "~/.config/waybar/modules/mail.py",
+        "exec-if": "test -f ~/.config/waybar/modules/mailsecrets.py",
         "tooltip": false
     },
     "tray": {

--- a/linux/arch/.config/waybar/config
+++ b/linux/arch/.config/waybar/config
@@ -24,7 +24,7 @@
         "format-icons": {
             "1": "",
             "2": "",
-            "3": "  ",
+            "3": "",
             "4": "",
         },
         "persistent-workspaces" : {

--- a/linux/arch/README.md
+++ b/linux/arch/README.md
@@ -67,6 +67,8 @@ This directory contains configuration files for my Arch Linux desktop setup.
      | xargs sudo pacman -S --needed
 
    # AUR (the installer uses yay or paru when one is available)
+   # Note: AUR installs run with --noconfirm for unattended installs, which
+   # skips PKGBUILD review; the declared set is pinned in packages-aur.list.
    grep -Ev '^[[:space:]]*(#|$)' packages-aur.list \
      | xargs paru -S --needed
    ```

--- a/linux/arch/README.md
+++ b/linux/arch/README.md
@@ -53,15 +53,22 @@ This directory contains configuration files for my Arch Linux desktop setup.
 - **Font**: FiraCode Nerd Font 10px
 - **Border radius**: 16px
 
+### Firefox
+- **Location**: `firefox/` in the repo; installed into the active profile
+  discovered from `~/.mozilla/firefox/profiles.ini`
+- **Theme**: Matches Sway, Waybar, GTK, mako, and Kitty
+- Restart Firefox after installing profile CSS
+
 ## Installation
 
 1. **Prerequisites**:
    ```bash
-   sudo pacman -S waybar kitty rofi mako grim slurp \
-                  firefox spotify-launcher steam
+   grep -Ev '^[[:space:]]*(#|$)' packages.list \
+     | xargs sudo pacman -S --needed
 
-   # AUR (pacman cannot install these; use an AUR helper)
-   paru -S swayfx slack-desktop nordic-theme
+   # AUR (the installer uses yay or paru when one is available)
+   grep -Ev '^[[:space:]]*(#|$)' packages-aur.list \
+     | xargs paru -S --needed
    ```
 
 2. **Install configs** (from the dotfiles root - configs are copied, never
@@ -70,12 +77,20 @@ This directory contains configuration files for my Arch Linux desktop setup.
    ./install.sh
    ```
 
+   Launch Firefox once before installing if it has no profile yet.
+
 3. **Reload Sway**:
    ```bash
    swaymsg reload
    ```
 
-4. **(Optional) auto-refresh the AI machine-state snapshot on package changes**
+4. **Verify live state and runtime dependencies**:
+   ```bash
+   ./install.sh --check
+   ./install.sh --doctor
+   ```
+
+5. **(Optional) auto-refresh the AI machine-state snapshot on package changes**
    (the installer deliberately does not enable this; it writes into the repo):
    ```bash
    sed -e "s|__DOTFILES_DIR__|$PWD|" -e "s|__DOTFILES_USER__|$USER|" \

--- a/linux/arch/firefox/chrome/userChrome.css
+++ b/linux/arch/firefox/chrome/userChrome.css
@@ -10,7 +10,6 @@
   --jm-surface: #332635;
   --jm-surface-raised: #4a3844;
   --jm-accent: #9d5a7f;
-  --jm-accent-strong: #cba6f7;
   --jm-accent-soft: #6b4456;
   --jm-text: #d0d0d0;
   --jm-text-bright: #cdd6f4;

--- a/linux/arch/firefox/chrome/userChrome.css
+++ b/linux/arch/firefox/chrome/userChrome.css
@@ -1,0 +1,189 @@
+/*
+ * Desktop-matched Firefox chrome.
+ * Palette is pulled from the local Sway, Waybar, mako, and kitty configs.
+ */
+
+:root {
+  --jm-bg: #221820;
+  --jm-bg-deep: #18121a;
+  --jm-bg-soft: #2a1e2e;
+  --jm-surface: #332635;
+  --jm-surface-raised: #4a3844;
+  --jm-accent: #9d5a7f;
+  --jm-accent-strong: #cba6f7;
+  --jm-accent-soft: #6b4456;
+  --jm-text: #d0d0d0;
+  --jm-text-bright: #cdd6f4;
+  --jm-muted: #8a8a8a;
+  --jm-border: #626262;
+  --jm-urgent: #d68787;
+
+  --toolbar-bgcolor: var(--jm-bg) !important;
+  --toolbar-color: var(--jm-text) !important;
+  --lwt-accent-color: var(--jm-bg-deep) !important;
+  --lwt-text-color: var(--jm-text) !important;
+  --lwt-selected-tab-background-color: var(--jm-bg-soft) !important;
+  --lwt-toolbar-field-background-color: var(--jm-bg-deep) !important;
+  --lwt-toolbar-field-color: var(--jm-text-bright) !important;
+  --lwt-toolbar-field-border-color: var(--jm-accent-soft) !important;
+  --lwt-toolbar-field-focus: var(--jm-bg-deep) !important;
+  --lwt-toolbar-field-focus-color: var(--jm-text-bright) !important;
+  --lwt-toolbar-field-focus-border-color: var(--jm-accent) !important;
+  --lwt-toolbarbutton-icon-fill: var(--jm-text) !important;
+  --arrowpanel-background: var(--jm-bg) !important;
+  --arrowpanel-color: var(--jm-text) !important;
+  --arrowpanel-border-color: var(--jm-accent-soft) !important;
+  --button-bgcolor: color-mix(in srgb, var(--jm-surface) 86%, transparent) !important;
+  --button-hover-bgcolor: color-mix(in srgb, var(--jm-accent-soft) 80%, transparent) !important;
+  --button-active-bgcolor: var(--jm-accent) !important;
+
+  color-scheme: dark !important;
+}
+
+#navigator-toolbox {
+  background: var(--jm-bg) !important;
+  border-bottom: 1px solid var(--jm-accent-soft) !important;
+}
+
+#titlebar,
+#TabsToolbar,
+#nav-bar,
+#PersonalToolbar {
+  background: var(--jm-bg) !important;
+  color: var(--jm-text) !important;
+}
+
+#TabsToolbar {
+  --tab-min-height: 34px !important;
+}
+
+.tab-background {
+  border-radius: 6px 6px 0 0 !important;
+  margin-block: 4px 0 !important;
+  border: 1px solid transparent !important;
+}
+
+.tabbrowser-tab:hover > .tab-stack > .tab-background:not([selected]) {
+  background: var(--jm-surface) !important;
+  border-color: color-mix(in srgb, var(--jm-accent-soft) 70%, transparent) !important;
+}
+
+.tabbrowser-tab[selected] > .tab-stack > .tab-background {
+  background: var(--jm-bg-soft) !important;
+  border-color: var(--jm-accent) !important;
+  box-shadow: inset 0 2px 0 var(--jm-accent) !important;
+}
+
+.tab-label {
+  color: var(--jm-text) !important;
+}
+
+.tabbrowser-tab[selected] .tab-label {
+  color: var(--jm-text-bright) !important;
+}
+
+.tab-close-button:hover,
+.toolbarbutton-1:hover > .toolbarbutton-icon,
+.toolbarbutton-1:hover > .toolbarbutton-badge-stack,
+.toolbarbutton-1[open] > .toolbarbutton-icon,
+.toolbarbutton-1[open] > .toolbarbutton-badge-stack {
+  background-color: var(--jm-accent-soft) !important;
+}
+
+#urlbar-background,
+#searchbar {
+  background: var(--jm-bg-deep) !important;
+  border: 1px solid var(--jm-accent-soft) !important;
+  box-shadow: none !important;
+}
+
+#urlbar[focused] #urlbar-background {
+  border-color: var(--jm-accent) !important;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--jm-accent) 70%, transparent) !important;
+}
+
+#urlbar-input,
+#searchbar input {
+  color: var(--jm-text-bright) !important;
+}
+
+#identity-icon-box,
+#tracking-protection-icon-container {
+  color: var(--jm-muted) !important;
+}
+
+#urlbar .urlbarView {
+  background: var(--jm-bg) !important;
+  border: 1px solid var(--jm-accent-soft) !important;
+  color: var(--jm-text) !important;
+}
+
+.urlbarView-row:hover,
+.urlbarView-row[selected] {
+  background: var(--jm-surface-raised) !important;
+  color: var(--jm-text-bright) !important;
+}
+
+menupopup,
+panel,
+.panel-arrowcontent {
+  --panel-background: var(--jm-bg) !important;
+  --panel-color: var(--jm-text) !important;
+  --panel-border-color: var(--jm-accent-soft) !important;
+  --panel-border-radius: 6px !important;
+  --panel-separator-color: var(--jm-border) !important;
+}
+
+menu,
+menuitem,
+.subviewbutton,
+.toolbaritem-combined-buttons > toolbarbutton {
+  color: var(--jm-text) !important;
+}
+
+menu:hover,
+menuitem:hover,
+.subviewbutton:hover,
+.subviewbutton[open],
+.subviewbutton:focus-visible {
+  background: var(--jm-surface-raised) !important;
+  color: var(--jm-text-bright) !important;
+}
+
+#sidebar-box,
+#sidebar-header {
+  background: var(--jm-bg) !important;
+  color: var(--jm-text) !important;
+  border-color: var(--jm-accent-soft) !important;
+}
+
+#sidebar-search-container,
+#sidebar {
+  background: var(--jm-bg-deep) !important;
+  color: var(--jm-text) !important;
+}
+
+findbar {
+  background: var(--jm-bg) !important;
+  color: var(--jm-text) !important;
+  border-top: 1px solid var(--jm-accent-soft) !important;
+}
+
+findbar textbox {
+  background: var(--jm-bg-deep) !important;
+  color: var(--jm-text-bright) !important;
+  border-color: var(--jm-accent-soft) !important;
+}
+
+.findbar-find-status {
+  color: var(--jm-muted) !important;
+}
+
+.findbar-find-status[status="notfound"] {
+  color: var(--jm-urgent) !important;
+}
+
+::-moz-selection {
+  background: var(--jm-accent) !important;
+  color: var(--jm-text-bright) !important;
+}

--- a/linux/arch/firefox/chrome/userContent.css
+++ b/linux/arch/firefox/chrome/userContent.css
@@ -1,0 +1,84 @@
+/*
+ * Keep a few Firefox settings pages aligned with the desktop palette.
+ * about:home and about:newtab are intentionally excluded so Firefox's
+ * activity-stream widgets/tiles keep their normal visibility behavior.
+ */
+
+@-moz-document url-prefix("about:preferences"),
+  url-prefix("about:addons"),
+  url-prefix("about:support"),
+  url-prefix("about:downloads"),
+  url-prefix("chrome://mozapps/content/") {
+  :root {
+    --jm-bg: #221820;
+    --jm-bg-deep: #18121a;
+    --jm-bg-soft: #2a1e2e;
+    --jm-surface: #332635;
+    --jm-surface-raised: #4a3844;
+    --jm-accent: #9d5a7f;
+    --jm-accent-strong: #cba6f7;
+    --jm-accent-soft: #6b4456;
+    --jm-text: #d0d0d0;
+    --jm-text-bright: #cdd6f4;
+    --jm-muted: #8a8a8a;
+    --jm-border: #626262;
+    --jm-urgent: #d68787;
+
+    color-scheme: dark !important;
+    --in-content-page-background: var(--jm-bg) !important;
+    --in-content-page-color: var(--jm-text) !important;
+    --in-content-box-background: var(--jm-bg-deep) !important;
+    --in-content-box-background-odd: var(--jm-bg-soft) !important;
+    --in-content-box-border-color: var(--jm-accent-soft) !important;
+    --in-content-border-color: var(--jm-accent-soft) !important;
+    --in-content-primary-button-background: var(--jm-accent) !important;
+    --in-content-primary-button-background-hover: var(--jm-accent-strong) !important;
+    --in-content-primary-button-text-color: var(--jm-bg-deep) !important;
+    --in-content-button-background: var(--jm-surface) !important;
+    --in-content-button-background-hover: var(--jm-surface-raised) !important;
+    --in-content-button-text-color: var(--jm-text) !important;
+    --in-content-link-color: var(--jm-accent-strong) !important;
+    --in-content-link-color-hover: #f5c2e7 !important;
+  }
+
+  body,
+  html {
+    background-color: var(--jm-bg) !important;
+    color: var(--jm-text) !important;
+  }
+
+  input,
+  textarea,
+  select,
+  menulist,
+  tree,
+  richlistbox,
+  listbox {
+    background-color: var(--jm-bg-deep) !important;
+    color: var(--jm-text-bright) !important;
+    border-color: var(--jm-accent-soft) !important;
+  }
+
+  button,
+  .button,
+  .category,
+  .sidebar-footer-button,
+  .text-link {
+    border-radius: 6px !important;
+  }
+
+  button:not(.primary) {
+    background-color: var(--jm-surface) !important;
+    color: var(--jm-text) !important;
+    border-color: var(--jm-accent-soft) !important;
+  }
+
+  button:not(.primary):hover {
+    background-color: var(--jm-surface-raised) !important;
+  }
+
+  ::selection {
+    background: var(--jm-accent) !important;
+    color: var(--jm-text-bright) !important;
+  }
+}

--- a/linux/arch/firefox/chrome/userContent.css
+++ b/linux/arch/firefox/chrome/userContent.css
@@ -20,9 +20,6 @@
     --jm-accent-soft: #6b4456;
     --jm-text: #d0d0d0;
     --jm-text-bright: #cdd6f4;
-    --jm-muted: #8a8a8a;
-    --jm-border: #626262;
-    --jm-urgent: #d68787;
 
     color-scheme: dark !important;
     --in-content-page-background: var(--jm-bg) !important;

--- a/linux/arch/firefox/user.js
+++ b/linux/arch/firefox/user.js
@@ -1,0 +1,2 @@
+// Enable userChrome.css and userContent.css in this Firefox profile.
+user_pref("toolkit.legacyUserProfileCustomizations.stylesheets", true);

--- a/linux/arch/packages-aur.list
+++ b/linux/arch/packages-aur.list
@@ -1,0 +1,5 @@
+# Desktop packages unavailable from the official Arch repositories.
+swayfx
+nordic-theme
+slack-desktop
+spotify

--- a/linux/arch/packages.list
+++ b/linux/arch/packages.list
@@ -20,12 +20,29 @@ wl-clipboard
 wtype
 waybar
 ttf-firacode-nerd
+fontconfig
 rofi
 mako
 grim
 slurp
 cliphist
 playerctl
+thunar
+ranger
+pavucontrol
+libnotify
+networkmanager
+iputils
+procps-ng
+libpulse
+swayidle
+swaylock
+xdg-desktop-portal
+xdg-desktop-portal-gtk
+xdg-desktop-portal-wlr
+xdg-utils
+firefox
+steam
 make
 neovim
 nodejs
@@ -50,6 +67,4 @@ bottom
 httpie
 yq
 
-# AUR (install with an AUR helper, e.g. paru -S; pacman cannot install these)
-# swayfx
-# nordic-theme (GTK theme referenced by gtk settings.ini)
+# AUR packages live in packages-aur.list and are installed with yay or paru.

--- a/linux/arch/packages.list
+++ b/linux/arch/packages.list
@@ -51,7 +51,7 @@ python
 python-pip
 python-virtualenv
 ripgrep
-rust
+rustup
 tmux
 tree
 vim

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-install-test.XXXXXX")"
+export DOTFILES_NO_RUNTIME_RELOAD=1
 TEST_HOME="$TMP_DIR/home"
 DRY_HOME="$TMP_DIR/dry-home"
 STUB_DIR="$TMP_DIR/bin"
@@ -17,10 +18,16 @@ trap cleanup EXIT
 
 mkdir -p \
     "$TEST_HOME/.mozilla/firefox/test.default/chrome" \
+    "$TEST_HOME/.ssh" \
     "$DRY_HOME" \
     "$STUB_DIR"
 
 printf 'pre-install bashrc\n' > "$TEST_HOME/.bashrc"
+cat > "$TEST_HOME/.ssh/config" <<'SSH_CONFIG'
+Host github.com
+  User git
+  IdentityFile ~/.ssh/github_ed25519
+SSH_CONFIG
 cat > "$TEST_HOME/.mozilla/firefox/profiles.ini" <<'PROFILE'
 [InstallTest]
 Default=test.default
@@ -85,6 +92,11 @@ assert_file "$TEST_HOME/.config/kitty/kitty.conf"
 assert_file "$TEST_HOME/.config/shell-functions/git.sh"
 assert_regular_copy "$TEST_HOME/.config/shell-functions/editor.sh" "$ROOT_DIR/common/shell-functions/editor.sh"
 assert_regular_copy "$TEST_HOME/.config/shell-functions/which.sh" "$ROOT_DIR/common/shell-functions/which.sh"
+assert_regular_copy "$TEST_HOME/.ssh/config.dotfiles" "$ROOT_DIR/common/ssh/config"
+grep -q 'Include ~/.ssh/config.dotfiles' "$TEST_HOME/.ssh/config" || fail "shared SSH include is missing"
+grep -q 'IdentityFile ~/.ssh/github_ed25519' "$TEST_HOME/.ssh/config" || fail "machine-local SSH identity was lost"
+! grep -Eq '^[[:space:]]*IdentityFile[[:space:]]' "$TEST_HOME/.ssh/config.dotfiles" \
+    || fail "shared SSH config must not select a machine-specific identity"
 
 AUDIT_LOG="$INSTALL_BACKUP/install-audit.tsv"
 [[ -f "$AUDIT_LOG" ]] || fail "audit log was not created"
@@ -92,6 +104,8 @@ grep -q $'\tcopy\t' "$AUDIT_LOG" || fail "audit log has no copy action"
 ! grep -q $'\tlink\t' "$AUDIT_LOG" || fail "audit log must not contain link actions"
 grep -q "$ROOT_DIR/common/nvim/init.vim" "$AUDIT_LOG" || fail "audit log does not include neovim init"
 grep -q '^pre-install bashrc$' "$INSTALL_BACKUP/files/.bashrc" || fail "pre-install bashrc was not backed up"
+grep -q 'IdentityFile ~/.ssh/github_ed25519' "$INSTALL_BACKUP/files/.ssh/config" \
+    || fail "machine-local SSH config was not backed up"
 
 if [[ -f /etc/os-release ]]; then
     # shellcheck disable=SC1091

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -4,15 +4,34 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-install-test.XXXXXX")"
 TEST_HOME="$TMP_DIR/home"
+DRY_HOME="$TMP_DIR/dry-home"
 STUB_DIR="$TMP_DIR/bin"
 STUB_LOG="$TMP_DIR/stubs.log"
+INSTALL_BACKUP="$TMP_DIR/install-backup"
+MANUAL_BACKUP="$TMP_DIR/manual-backup"
 
 cleanup() {
     rm -rf "$TMP_DIR"
 }
 trap cleanup EXIT
 
-mkdir -p "$TEST_HOME" "$STUB_DIR"
+mkdir -p \
+    "$TEST_HOME/.mozilla/firefox/test.default/chrome" \
+    "$DRY_HOME" \
+    "$STUB_DIR"
+
+printf 'pre-install bashrc\n' > "$TEST_HOME/.bashrc"
+cat > "$TEST_HOME/.mozilla/firefox/profiles.ini" <<'PROFILE'
+[InstallTest]
+Default=test.default
+Locked=1
+
+[Profile0]
+Name=default
+IsRelative=1
+Path=test.default
+Default=1
+PROFILE
 
 cat > "$STUB_DIR/vim" <<'STUB'
 #!/usr/bin/env bash
@@ -49,6 +68,8 @@ assert_file() {
 HOME="$TEST_HOME" \
 PATH="$STUB_DIR:$PATH" \
 DOTFILES_INSTALL_TEST_LOG="$STUB_LOG" \
+DOTFILES_BACKUP_DIR="$INSTALL_BACKUP" \
+DOTFILES_FULL_INSTALL=1 \
     "$ROOT_DIR/install.sh" --no-packages > "$TMP_DIR/install.log"
 
 assert_regular_copy "$TEST_HOME/.bashrc" "$ROOT_DIR/common/shell/.bashrc"
@@ -65,11 +86,62 @@ assert_file "$TEST_HOME/.config/shell-functions/git.sh"
 assert_regular_copy "$TEST_HOME/.config/shell-functions/editor.sh" "$ROOT_DIR/common/shell-functions/editor.sh"
 assert_regular_copy "$TEST_HOME/.config/shell-functions/which.sh" "$ROOT_DIR/common/shell-functions/which.sh"
 
-AUDIT_LOG="$(find "$TEST_HOME" -path '*/.dotfiles-backup-*/install-audit.tsv' -print -quit)"
-[[ -n "$AUDIT_LOG" ]] || fail "audit log was not created"
+AUDIT_LOG="$INSTALL_BACKUP/install-audit.tsv"
+[[ -f "$AUDIT_LOG" ]] || fail "audit log was not created"
 grep -q $'\tcopy\t' "$AUDIT_LOG" || fail "audit log has no copy action"
 ! grep -q $'\tlink\t' "$AUDIT_LOG" || fail "audit log must not contain link actions"
 grep -q "$ROOT_DIR/common/nvim/init.vim" "$AUDIT_LOG" || fail "audit log does not include neovim init"
+grep -q '^pre-install bashrc$' "$INSTALL_BACKUP/files/.bashrc" || fail "pre-install bashrc was not backed up"
+
+if [[ -f /etc/os-release ]]; then
+    # shellcheck disable=SC1091
+    source /etc/os-release
+    if [[ "${ID,,}" == "arch" ]]; then
+        assert_regular_copy "$TEST_HOME/.mozilla/firefox/test.default/user.js" "$ROOT_DIR/linux/arch/firefox/user.js"
+        assert_regular_copy "$TEST_HOME/.mozilla/firefox/test.default/chrome/userChrome.css" "$ROOT_DIR/linux/arch/firefox/chrome/userChrome.css"
+        assert_regular_copy "$TEST_HOME/.mozilla/firefox/test.default/chrome/userContent.css" "$ROOT_DIR/linux/arch/firefox/chrome/userContent.css"
+    fi
+fi
+
+if ! HOME="$TEST_HOME" \
+    PATH="$STUB_DIR:$PATH" \
+    DOTFILES_INSTALL_TEST_LOG="$STUB_LOG" \
+    DOTFILES_FULL_INSTALL=1 \
+        "$ROOT_DIR/install.sh" --check > "$TMP_DIR/check-clean.log" 2>&1; then
+    cat "$TMP_DIR/check-clean.log" >&2
+    fail "--check rejected a clean install"
+fi
+
+printf 'locally changed zshrc\n' > "$TEST_HOME/.zshrc"
+if HOME="$TEST_HOME" PATH="$STUB_DIR:$PATH" DOTFILES_FULL_INSTALL=1 \
+    "$ROOT_DIR/install.sh" --check > "$TMP_DIR/check-drift.log" 2>&1; then
+    fail "--check did not detect a changed zshrc"
+fi
+
+HOME="$TEST_HOME" \
+PATH="$STUB_DIR:$PATH" \
+DOTFILES_INSTALL_TEST_LOG="$STUB_LOG" \
+DOTFILES_BACKUP_DIR="$MANUAL_BACKUP" \
+DOTFILES_FULL_INSTALL=1 \
+    "$ROOT_DIR/install.sh" --backup-only > "$TMP_DIR/backup.log"
+grep -q '^locally changed zshrc$' "$MANUAL_BACKUP/files/.zshrc" || fail "--backup-only did not preserve live drift"
+grep -q '^locally changed zshrc$' "$TEST_HOME/.zshrc" || fail "--backup-only changed the live file"
+
+cp "$ROOT_DIR/common/shell/.zshrc" "$TEST_HOME/.zshrc"
+if ! HOME="$TEST_HOME" PATH="$STUB_DIR:$PATH" DOTFILES_FULL_INSTALL=1 \
+    "$ROOT_DIR/install.sh" --check > "$TMP_DIR/check-restored.log" 2>&1; then
+    cat "$TMP_DIR/check-restored.log" >&2
+    fail "--check rejected the restored install"
+fi
+
+HOME="$DRY_HOME" \
+PATH="$STUB_DIR:$PATH" \
+DOTFILES_INSTALL_TEST_LOG="$STUB_LOG" \
+DOTFILES_BACKUP_DIR="$TMP_DIR/dry-backup" \
+DOTFILES_FULL_INSTALL=1 \
+    "$ROOT_DIR/install.sh" --dry-run --no-packages > "$TMP_DIR/dry-run.log"
+[[ -z "$(find "$DRY_HOME" -mindepth 1 -print -quit)" ]] || fail "--dry-run changed HOME"
+[[ ! -e "$TMP_DIR/dry-backup" ]] || fail "--dry-run created a backup directory"
 
 # vim step defers to nvim when nvim exists (stubbed here), so no vim invocation
 ! grep -q '^vim ' "$STUB_LOG" || fail "vim should not be invoked when nvim is present"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-install-test.XXXXXX")"
-export DOTFILES_NO_RUNTIME_RELOAD=1
 TEST_HOME="$TMP_DIR/home"
 DRY_HOME="$TMP_DIR/dry-home"
 STUB_DIR="$TMP_DIR/bin"
@@ -72,12 +71,21 @@ assert_file() {
     [[ -f "$path" ]] || fail "$path is not a file"
 }
 
-HOME="$TEST_HOME" \
-PATH="$STUB_DIR:$PATH" \
-DOTFILES_INSTALL_TEST_LOG="$STUB_LOG" \
-DOTFILES_BACKUP_DIR="$INSTALL_BACKUP" \
-DOTFILES_FULL_INSTALL=1 \
-    "$ROOT_DIR/install.sh" --no-packages > "$TMP_DIR/install.log"
+run_installer() {
+    local home="$1"
+    local backup_dir="$2"
+    shift 2
+
+    HOME="$home" \
+    PATH="$STUB_DIR:$PATH" \
+    KITTY_PID='' \
+    DOTFILES_INSTALL_TEST_LOG="$STUB_LOG" \
+    DOTFILES_BACKUP_DIR="$backup_dir" \
+    DOTFILES_FULL_INSTALL=1 \
+        "$ROOT_DIR/install.sh" "$@"
+}
+
+run_installer "$TEST_HOME" "$INSTALL_BACKUP" --no-packages > "$TMP_DIR/install.log"
 
 assert_regular_copy "$TEST_HOME/.bashrc" "$ROOT_DIR/common/shell/.bashrc"
 assert_regular_copy "$TEST_HOME/.zshrc" "$ROOT_DIR/common/shell/.zshrc"
@@ -117,43 +125,27 @@ if [[ -f /etc/os-release ]]; then
     fi
 fi
 
-if ! HOME="$TEST_HOME" \
-    PATH="$STUB_DIR:$PATH" \
-    DOTFILES_INSTALL_TEST_LOG="$STUB_LOG" \
-    DOTFILES_FULL_INSTALL=1 \
-        "$ROOT_DIR/install.sh" --check > "$TMP_DIR/check-clean.log" 2>&1; then
+if ! run_installer "$TEST_HOME" "$INSTALL_BACKUP" --check > "$TMP_DIR/check-clean.log" 2>&1; then
     cat "$TMP_DIR/check-clean.log" >&2
     fail "--check rejected a clean install"
 fi
 
 printf 'locally changed zshrc\n' > "$TEST_HOME/.zshrc"
-if HOME="$TEST_HOME" PATH="$STUB_DIR:$PATH" DOTFILES_FULL_INSTALL=1 \
-    "$ROOT_DIR/install.sh" --check > "$TMP_DIR/check-drift.log" 2>&1; then
+if run_installer "$TEST_HOME" "$INSTALL_BACKUP" --check > "$TMP_DIR/check-drift.log" 2>&1; then
     fail "--check did not detect a changed zshrc"
 fi
 
-HOME="$TEST_HOME" \
-PATH="$STUB_DIR:$PATH" \
-DOTFILES_INSTALL_TEST_LOG="$STUB_LOG" \
-DOTFILES_BACKUP_DIR="$MANUAL_BACKUP" \
-DOTFILES_FULL_INSTALL=1 \
-    "$ROOT_DIR/install.sh" --backup-only > "$TMP_DIR/backup.log"
+run_installer "$TEST_HOME" "$MANUAL_BACKUP" --backup-only > "$TMP_DIR/backup.log"
 grep -q '^locally changed zshrc$' "$MANUAL_BACKUP/files/.zshrc" || fail "--backup-only did not preserve live drift"
 grep -q '^locally changed zshrc$' "$TEST_HOME/.zshrc" || fail "--backup-only changed the live file"
 
 cp "$ROOT_DIR/common/shell/.zshrc" "$TEST_HOME/.zshrc"
-if ! HOME="$TEST_HOME" PATH="$STUB_DIR:$PATH" DOTFILES_FULL_INSTALL=1 \
-    "$ROOT_DIR/install.sh" --check > "$TMP_DIR/check-restored.log" 2>&1; then
+if ! run_installer "$TEST_HOME" "$INSTALL_BACKUP" --check > "$TMP_DIR/check-restored.log" 2>&1; then
     cat "$TMP_DIR/check-restored.log" >&2
     fail "--check rejected the restored install"
 fi
 
-HOME="$DRY_HOME" \
-PATH="$STUB_DIR:$PATH" \
-DOTFILES_INSTALL_TEST_LOG="$STUB_LOG" \
-DOTFILES_BACKUP_DIR="$TMP_DIR/dry-backup" \
-DOTFILES_FULL_INSTALL=1 \
-    "$ROOT_DIR/install.sh" --dry-run --no-packages > "$TMP_DIR/dry-run.log"
+run_installer "$DRY_HOME" "$TMP_DIR/dry-backup" --dry-run --no-packages > "$TMP_DIR/dry-run.log"
 [[ -z "$(find "$DRY_HOME" -mindepth 1 -print -quit)" ]] || fail "--dry-run changed HOME"
 [[ ! -e "$TMP_DIR/dry-backup" ]] || fail "--dry-run created a backup directory"
 

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -79,6 +79,7 @@ run_installer() {
     HOME="$home" \
     PATH="$STUB_DIR:$PATH" \
     KITTY_PID='' \
+    DOTFILES_SKIP_PRIVATE_SKILLS="${DOTFILES_SKIP_PRIVATE_SKILLS:-1}" \
     DOTFILES_INSTALL_TEST_LOG="$STUB_LOG" \
     DOTFILES_BACKUP_DIR="$backup_dir" \
     DOTFILES_FULL_INSTALL=1 \
@@ -105,6 +106,15 @@ grep -q 'Include ~/.ssh/config.dotfiles' "$TEST_HOME/.ssh/config" || fail "share
 grep -q 'IdentityFile ~/.ssh/github_ed25519' "$TEST_HOME/.ssh/config" || fail "machine-local SSH identity was lost"
 ! grep -Eq '^[[:space:]]*IdentityFile[[:space:]]' "$TEST_HOME/.ssh/config.dotfiles" \
     || fail "shared SSH config must not select a machine-specific identity"
+
+if [[ "${DOTFILES_SKIP_PRIVATE_SKILLS:-1}" == "0" ]]; then
+    assert_regular_copy "$TEST_HOME/.agents/skills/autoresearch/SKILL.md" \
+        "$ROOT_DIR/private/skills/autoresearch/SKILL.md"
+    assert_regular_copy "$TEST_HOME/.agents/skills/skillpack-sync/SKILL.md" \
+        "$ROOT_DIR/private/skills/skillpack-sync/SKILL.md"
+    [[ ! -e "$TEST_HOME/.agents/skills/archive-triage" ]] \
+        || fail "candidate private skill was installed"
+fi
 
 AUDIT_LOG="$INSTALL_BACKUP/install-audit.tsv"
 [[ -f "$AUDIT_LOG" ]] || fail "audit log was not created"


### PR DESCRIPTION
## Summary

- add auditable `--check`, `--backup-only`, and `--doctor` installer modes
- back up and install the active Firefox profile's `user.js`, `userChrome.css`, and `userContent.css`
- reconcile Arch runtime and AUR package declarations, including failure-tolerant package installation
- preserve the Waybar/Sway/GTK/file-picker configuration currently running on the home box
- force one final Kitty reload after config/theme replacement to avoid a black partial-reload state
- preserve machine-local SSH identities and keep shared SSH defaults free of machine-specific key paths
- pin the private `woud420/skills` repository as `private/skills` and copy its Git-tracked active/maintenance profile into `~/.agents/skills`
- remove Thunderbird assumptions and the Git AI shell/Git integration

## Verification

- `make check`
- `shellcheck install.sh scripts/test-install.sh`
- `DOTFILES_SKIP_PRIVATE_SKILLS=0 ./scripts/test-install.sh`
- fresh non-recursive clone auto-initializes the authenticated private submodule
- public CI explicitly skips private credentials
- `./install.sh --backup-only`
- `./install.sh --check` (154 managed files match)
- `./install.sh --doctor` (all runtime dependencies present)
- Sway reload, Waybar restart, and desktop screenshot inspection
- live Kitty SIGUSR1 reload restored the configured plum/translucent background
- all tracked SSH keys parse; public/private fingerprints match; GitHub authentication succeeds with `github_ed25519`
- GitHub Actions: lint, Arch, Debian, and macOS all pass

## Notes

- The public repository records only the private submodule URL and pinned commit; it contains no private skill content or credentials.
- The installed private profile currently contains 13 skills and 66 tracked files. Candidate and untracked skills are excluded.
- The live pre-install snapshot is at `~/.dotfiles-backup-20260711_165250`; the install-time snapshot is at `~/.dotfiles-backup-20260711_165452`.
- `bottom` is the only declared optional package not currently installed because this machine's pacman sync database references a mirror-pruned version. Resolving that safely requires a full `pacman -Syu`; it is not used by the managed desktop configuration.
